### PR TITLE
Rework when the Compile command is being assembled

### DIFF
--- a/clangplugin.cpp
+++ b/clangplugin.cpp
@@ -3,7 +3,7 @@
  */
 
 #include <sdk.h>
-
+#include <stdio.h>
 #include "clangplugin.h"
 
 #include <cbcolourmanager.h>
@@ -14,51 +14,68 @@
 #include <wx/tokenzr.h>
 
 #ifndef CB_PRECOMP
-    #include <cbeditor.h>
-    #include <cbproject.h>
-    #include <compilerfactory.h>
-    #include <configmanager.h>
-    #include <editorcolourset.h>
-    #include <editormanager.h>
-    #include <logmanager.h>
-    #include <macrosmanager.h>
-    #include <projectfile.h>
-    #include <projectmanager.h>
+#include <cbeditor.h>
+#include <cbproject.h>
+#include <compilerfactory.h>
+#include <configmanager.h>
+#include <editorcolourset.h>
+#include <editormanager.h>
+#include <logmanager.h>
+#include <macrosmanager.h>
+#include <projectfile.h>
+#include <projectmanager.h>
 
-    #include <algorithm>
-    #include <wx/dir.h>
+#include <algorithm>
+#include <wx/dir.h>
 #endif // CB_PRECOMP
 
 // this auto-registers the plugin
-namespace
-{
+namespace {
     PluginRegistrant<ClangPlugin> reg(wxT("ClangLib"));
 }
 
 static const wxString g_InvalidStr(wxT("invalid"));
-const int idEdOpenTimer     = wxNewId();
+//const int idEdOpenTimer     = wxNewId();
 const int idReparseTimer    = wxNewId();
-const int idDiagnosticTimer = wxNewId();
+//const int idDiagnosticTimer = wxNewId();
 const int idHightlightTimer = wxNewId();
-
 const int idGotoDeclaration = wxNewId();
+const int idCreateTranslationUnit = wxNewId();
+const int idReparse = wxNewId();
+const int idDiagnoseEd = wxNewId();
 
 // milliseconds
 #define ED_OPEN_DELAY 1000
 #define ED_ACTIVATE_DELAY 150
 #define REPARSE_DELAY 900
-#define DIAGNOSTIC_DELAY 3000
+//#define DIAGNOSTIC_DELAY 3000
 #define HIGHTLIGHT_DELAY 1700
 
+DEFINE_EVENT_TYPE(cbEVT_COMMAND_CREATETRANSLATIONUNIT)
+DEFINE_EVENT_TYPE(cbEVT_COMMAND_REPARSE)
+DEFINE_EVENT_TYPE(cbEVT_COMMAND_DIAGNOSEED)
+
+// Asynchronous events received
+DEFINE_EVENT_TYPE(cbEVT_CLANG_CREATETU_FINISHED)
+DEFINE_EVENT_TYPE(cbEVT_CLANG_REPARSE_FINISHED)
+DEFINE_EVENT_TYPE(cbEVT_CLANG_GETDIAGNOSTICS_FINISHED)
+DEFINE_EVENT_TYPE(cbEVT_CLANG_SYNCTASK_FINISHED)
+
+const int idClangCreateTU = wxNewId();
+const int idClangReparse = wxNewId();
+const int idClangGetDiagnostics = wxNewId();
+const int idClangSyncTask = wxNewId();
+
 ClangPlugin::ClangPlugin() :
-    m_Proxy(m_Database, m_CppKeywords),
+    m_Proxy(this, m_Database, m_CppKeywords),
     m_ImageList(16, 16),
-    m_EdOpenTimer(this, idEdOpenTimer),
+    //m_EdOpenTimer(this, idEdOpenTimer),
     m_ReparseTimer(this, idReparseTimer),
-    m_DiagnosticTimer(this, idDiagnosticTimer),
+    //m_DiagnosticTimer(this, idDiagnosticTimer),
     m_HightlightTimer(this, idHightlightTimer),
     m_pLastEditor(nullptr),
-    m_TranslUnitId(wxNOT_FOUND)
+    m_TranslUnitId(wxNOT_FOUND),
+    m_Parsing(0)
 {
     if (!Manager::LoadResource(_T("clanglib.zip")))
         NotifyMissingFile(_T("clanglib.zip"));
@@ -73,7 +90,8 @@ void ClangPlugin::OnAttach()
     wxBitmap bmp;
     wxString prefix = ConfigManager::GetDataFolder() + wxT("/images/codecompletion/");
     // bitmaps must be added by order of PARSER_IMG_* consts (which are also TokenCategory enums)
-    const char* imgs[] = {
+    const char* imgs[] =
+    {
         "class_folder.png",        // PARSER_IMG_CLASS_FOLDER
         "class.png",               // PARSER_IMG_CLASS
         "class_private.png",       // PARSER_IMG_CLASS_PRIVATE
@@ -130,13 +148,24 @@ void ClangPlugin::OnAttach()
     typedef cbEventFunctor<ClangPlugin, CodeBlocksEvent> ClEvent;
     Manager::Get()->RegisterEventSink(cbEVT_EDITOR_OPEN,      new ClEvent(this, &ClangPlugin::OnEditorOpen));
     Manager::Get()->RegisterEventSink(cbEVT_EDITOR_ACTIVATED, new ClEvent(this, &ClangPlugin::OnEditorActivate));
+    Manager::Get()->RegisterEventSink(cbEVT_EDITOR_SAVE,      new ClEvent(this, &ClangPlugin::OnEditorSave));
     Manager::Get()->RegisterEventSink(cbEVT_PROJECT_ACTIVATE, new ClEvent(this, &ClangPlugin::OnProjectActivate));
-    Connect(idEdOpenTimer,     wxEVT_TIMER, wxTimerEventHandler(ClangPlugin::OnTimer));
-    Connect(idReparseTimer,    wxEVT_TIMER, wxTimerEventHandler(ClangPlugin::OnTimer));
-    Connect(idDiagnosticTimer, wxEVT_TIMER, wxTimerEventHandler(ClangPlugin::OnTimer));
-    Connect(idHightlightTimer, wxEVT_TIMER, wxTimerEventHandler(ClangPlugin::OnTimer));
-    Connect(idGotoDeclaration, wxEVT_COMMAND_MENU_SELECTED, /*wxMenuEventHandler*/wxCommandEventHandler(ClangPlugin::OnGotoDeclaration), nullptr, this);
+    Manager::Get()->RegisterEventSink(cbEVT_PROJECT_OPTIONS_CHANGED, new ClEvent(this, &ClangPlugin::OnProjectOptionsChanged));
+    //Connect(idEdOpenTimer,        wxEVT_TIMER, wxTimerEventHandler(ClangPlugin::OnTimer));
+    Connect(idReparseTimer,       wxEVT_TIMER, wxTimerEventHandler(ClangPlugin::OnTimer));
+    //Connect(idDiagnosticTimer,    wxEVT_TIMER, wxTimerEventHandler(ClangPlugin::OnTimer));
+    Connect(idHightlightTimer,      wxEVT_TIMER, wxTimerEventHandler(ClangPlugin::OnTimer));
+    Connect(idGotoDeclaration,      wxEVT_COMMAND_MENU_SELECTED, /*wxMenuEventHandler*/wxCommandEventHandler(ClangPlugin::OnGotoDeclaration), nullptr, this);
+    Connect(idCreateTranslationUnit,cbEVT_COMMAND_CREATETRANSLATIONUNIT, wxCommandEventHandler(ClangPlugin::OnCreateTranslationUnit), nullptr, this);
+    Connect(idReparse,              cbEVT_COMMAND_REPARSE, wxCommandEventHandler(ClangPlugin::OnReparse), nullptr, this);
+    Connect(idDiagnoseEd,           cbEVT_COMMAND_DIAGNOSEED, wxCommandEventHandler(ClangPlugin::OnDiagnoseEd), nullptr, this);
+    Connect(idClangCreateTU,        cbEVT_CLANG_CREATETU_FINISHED, wxEventHandler(ClangPlugin::OnClangCreateTUFinished), nullptr, this);
+    Connect(idClangReparse,         cbEVT_CLANG_REPARSE_FINISHED, wxEventHandler(ClangPlugin::OnClangReparseFinished), nullptr, this);
+    Connect(idClangGetDiagnostics,  cbEVT_CLANG_GETDIAGNOSTICS_FINISHED, wxEventHandler(ClangPlugin::OnClangGetDiagnosticsFinished), nullptr, this);
+    Connect(idClangSyncTask       , cbEVT_CLANG_SYNCTASK_FINISHED, wxEventHandler(ClangPlugin::OnClangSyncTaskFinished), nullptr, this);
+
     m_EditorHookId = EditorHooks::RegisterHook(new EditorHooks::HookFunctor<ClangPlugin>(this, &ClangPlugin::OnEditorHook));
+
 }
 
 void ClangPlugin::OnRelease(bool WXUNUSED(appShutDown))
@@ -144,9 +173,9 @@ void ClangPlugin::OnRelease(bool WXUNUSED(appShutDown))
     EditorHooks::UnregisterHook(m_EditorHookId);
     Disconnect(idGotoDeclaration);
     Disconnect(idHightlightTimer);
-    Disconnect(idDiagnosticTimer);
+    //Disconnect(idDiagnosticTimer);
     Disconnect(idReparseTimer);
-    Disconnect(idEdOpenTimer);
+    //Disconnect(idEdOpenTimer);
     Manager::Get()->RemoveAllEventSinksFor(this);
     m_ImageList.RemoveAll();
 }
@@ -175,18 +204,25 @@ static wxString GetActualName(const wxString& name)
 }
 
 std::vector<ClangPlugin::CCToken> ClangPlugin::GetAutocompList(bool isAuto, cbEditor* ed,
-                                                               int& tknStart, int& tknEnd)
+        int& tknStart, int& tknEnd)
 {
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+
     std::vector<CCToken> tokens;
-    if (ed != m_pLastEditor)
+
+    if( m_Parsing > 0 )
     {
-        m_TranslUnitId = m_Proxy.GetTranslationUnitId(ed->GetFilename());
-        m_pLastEditor = ed;
+        Manager::Get()->GetLogManager()->LogWarning(wxT("ClangLib: Cannot autocomplete, still parsing ") + ed->GetFilename());
+        return tokens;
+    }
+    if (ed  != m_pLastEditor)
+    {
+        return tokens;
     }
     if (m_TranslUnitId == wxNOT_FOUND)
     {
         Manager::Get()->GetLogManager()->LogWarning(wxT("ClangLib: m_TranslUnitId == wxNOT_FOUND, "
-                                                        "cannot complete in file ") + ed->GetFilename());
+                "cannot complete in file ") + ed->GetFilename());
         return tokens;
     }
 
@@ -197,16 +233,15 @@ std::vector<ClangPlugin::CCToken> ClangPlugin::GetAutocompList(bool isAuto, cbEd
     {
         if (   (   curChar == wxT(':') // scope operator
                 && stc->GetCharAt(tknEnd - 2) != wxT(':') )
-            || (   curChar == wxT('>') // '->'
-                && stc->GetCharAt(tknEnd - 2) != wxT('-') )
-            || (   wxString(wxT("<\"/")).Find(curChar) != wxNOT_FOUND // #include directive (TODO: enumerate completable include files)
-                && !stc->IsPreprocessor(style) ) )
+                || (   curChar == wxT('>') // '->'
+                        && stc->GetCharAt(tknEnd - 2) != wxT('-') )
+                || (   wxString(wxT("<\"/")).Find(curChar) != wxNOT_FOUND // #include directive (TODO: enumerate completable include files)
+                        && !stc->IsPreprocessor(style) ) )
         {
             return tokens;
         }
     }
 
-    std::vector<ClToken> tknResults;
     const int line = stc->LineFromPosition(tknStart);
     std::map<wxString, wxString> unsavedFiles;
     EditorManager* edMgr = Manager::Get()->GetEditorManager();
@@ -215,20 +250,19 @@ std::vector<ClangPlugin::CCToken> ClangPlugin::GetAutocompList(bool isAuto, cbEd
         cbEditor* editor = edMgr->GetBuiltinEditor(i);
         if (editor && editor->GetModified())
             unsavedFiles.insert(std::make_pair(editor->GetFilename(),
-                                               editor->GetControl()->GetText()));
+                    editor->GetControl()->GetText()));
     }
     const int lnStart = stc->PositionFromLine(line);
     int column = tknStart - lnStart;
     for (; column > 0; --column)
     {
         if (   !wxIsspace(stc->GetCharAt(lnStart + column - 1))
-            || (column != 1 && !wxIsspace(stc->GetCharAt(lnStart + column - 2))) )
+                || (column != 1 && !wxIsspace(stc->GetCharAt(lnStart + column - 2))) )
         {
             break;
         }
     }
-    m_Proxy.CodeCompleteAt(isAuto, ed->GetFilename(), line + 1, column + 1,
-                           m_TranslUnitId, unsavedFiles, tknResults);
+
     const wxString& prefix = stc->GetTextRange(tknStart, tknEnd).Lower();
     bool includeCtors = true; // sometimes we get a lot of these
     for (int i = tknStart - 1; i > 0; --i)
@@ -241,10 +275,22 @@ std::vector<ClangPlugin::CCToken> ClangPlugin::GetAutocompList(bool isAuto, cbEd
             break;
         }
     }
+
+
+    ClangProxy::CodeCompleteAtTask task( cbEVT_CLANG_SYNCTASK_FINISHED, idClangSyncTask, isAuto, ed->GetFilename(), line+1, column+1, m_TranslUnitId, unsavedFiles);
+    m_Proxy.AddPendingTask(task);
+    if( wxCOND_TIMEOUT == task.WaitCompletion(100) )
+    {
+        std::cout<<"Timeout waiting for code completion"<<std::endl;
+        return tokens;
+    }
+    std::vector<ClToken> tknResults = task.GetResults();
+    //m_Proxy.CodeCompleteAt(isAuto, ed->GetFilename(), line + 1, column + 1,
+    //        m_TranslUnitId, unsavedFiles, tknResults);
     if (prefix.Length() > 3) // larger context, match the prefix at any point in the token
     {
         for (std::vector<ClToken>::const_iterator tknIt = tknResults.begin();
-             tknIt != tknResults.end(); ++tknIt)
+                tknIt != tknResults.end(); ++tknIt)
         {
             if (tknIt->name.Lower().Find(prefix) != wxNOT_FOUND && (includeCtors || tknIt->category != tcCtorPublic))
                 tokens.push_back(CCToken(tknIt->id, tknIt->name, tknIt->name, tknIt->weight, tknIt->category));
@@ -253,7 +299,7 @@ std::vector<ClangPlugin::CCToken> ClangPlugin::GetAutocompList(bool isAuto, cbEd
     else if (prefix.IsEmpty())
     {
         for (std::vector<ClToken>::const_iterator tknIt = tknResults.begin();
-             tknIt != tknResults.end(); ++tknIt)
+                tknIt != tknResults.end(); ++tknIt)
         {
             // it is rather unlikely for an operator to be the desired completion
             if (!tknIt->name.StartsWith(wxT("operator")) && (includeCtors || tknIt->category != tcCtorPublic))
@@ -263,7 +309,7 @@ std::vector<ClangPlugin::CCToken> ClangPlugin::GetAutocompList(bool isAuto, cbEd
     else // smaller context, only allow matches of the prefix at the beginning of the token
     {
         for (std::vector<ClToken>::const_iterator tknIt = tknResults.begin();
-             tknIt != tknResults.end(); ++tknIt)
+                tknIt != tknResults.end(); ++tknIt)
         {
             if (tknIt->name.Lower().StartsWith(prefix) && (includeCtors || tknIt->category != tcCtorPublic))
                 tokens.push_back(CCToken(tknIt->id, tknIt->name, tknIt->name, tknIt->weight, tknIt->category));
@@ -283,30 +329,31 @@ std::vector<ClangPlugin::CCToken> ClangPlugin::GetAutocompList(bool isAuto, cbEd
         bool isPP = stc->GetLine(line).Strip(wxString::leading).StartsWith(wxT("#"));
         std::set<int> usedWeights;
         for (std::vector<CCToken>::iterator tknIt = tokens.begin();
-             tknIt != tokens.end(); ++tknIt)
+                tknIt != tokens.end(); ++tknIt)
         {
             usedWeights.insert(tknIt->weight);
             switch (tknIt->category)
             {
-                case tcNone:
-                    if (isPP)
-                        tknIt->category = tcMacroDef;
-                    else if (std::binary_search(m_CppKeywords.begin(), m_CppKeywords.end(), GetActualName(tknIt->name)))
-                        tknIt->category = tcLangKeyword;
-                    break;
+            case tcNone:
+                if (isPP)
+                    tknIt->category = tcMacroDef;
+                else if (std::binary_search(m_CppKeywords.begin(), m_CppKeywords.end(), GetActualName(tknIt->name)))
+                    tknIt->category = tcLangKeyword;
+                break;
 
-                case tcClass:
-                case tcCtorPublic:
-                case tcDtorPublic:
-                case tcFuncPublic:
-                case tcVarPublic:
-                case tcEnum:
-                case tcTypedef:
-                    m_Proxy.RefineTokenType(m_TranslUnitId, tknIt->id, tknIt->category);
-                    break;
+            case tcClass:
+            case tcCtorPublic:
+            case tcDtorPublic:
+            case tcFuncPublic:
+            case tcVarPublic:
+            case tcEnum:
+            case tcTypedef:
+                // TODO
+                //m_Proxy.RefineTokenType(m_TranslUnitId, tknIt->id, tknIt->category);
+                break;
 
-                default:
-                    break;
+            default:
+                break;
             }
         }
         // Clang sometimes gives many weight values, which can make completion more difficult
@@ -322,33 +369,40 @@ std::vector<ClangPlugin::CCToken> ClangPlugin::GetAutocompList(bool isAuto, cbEd
             for (size_t i = 2; i < weightsVec.size(); ++i)
                 weightCompr[weightsVec[i]] = weightsVec[(i - 2) / factor + 2];
             for (std::vector<CCToken>::iterator tknIt = tokens.begin();
-                 tknIt != tokens.end(); ++tknIt)
+                    tknIt != tokens.end(); ++tknIt)
             {
                 tknIt->weight = weightCompr[tknIt->weight];
             }
         }
     }
 
+    std::cout<<"CodeCompletion finished"<<std::endl;
     return tokens;
 }
 
 wxString ClangPlugin::GetDocumentation(const CCToken& token)
 {
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     if (token.id >= 0)
         return m_Proxy.DocumentCCToken(m_TranslUnitId, token.id);
     return wxEmptyString;
 }
 
-std::vector<ClangPlugin::CCCallTip> ClangPlugin::GetCallTips(int pos, int style, cbEditor* ed, int& argsPos)
+std::vector<ClangPlugin::CCCallTip> ClangPlugin::GetCallTips(int pos, int /*style*/, cbEditor* ed, int& argsPos)
 {
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     std::vector<CCCallTip> tips;
+
     if (ed != m_pLastEditor)
     {
         m_TranslUnitId = m_Proxy.GetTranslationUnitId(ed->GetFilename());
         m_pLastEditor = ed;
     }
     if (m_TranslUnitId == wxNOT_FOUND)
+    {
+        std::cout<<"GetCallTips: No translUnitId yet"<<std::endl;
         return tips;
+    }
 
     cbStyledTextCtrl* stc = ed->GetControl();
 
@@ -359,15 +413,18 @@ std::vector<ClangPlugin::CCCallTip> ClangPlugin::GetCallTips(int pos, int style,
     {
         const int curStyle = stc->GetStyleAt(pos);
         if (   stc->IsString(curStyle)
-            || stc->IsCharacter(curStyle)
-            || stc->IsComment(curStyle) )
+                || stc->IsCharacter(curStyle)
+                || stc->IsComment(curStyle) )
         {
             continue;
         }
 
         const wxChar ch = stc->GetCharAt(pos);
         if (ch == wxT(';'))
+        {
+            std::cout<<"GetCalltips: Error?"<<std::endl;
             return tips; // error?
+        }
         else if (ch == wxT(','))
         {
             if (nest == 0)
@@ -385,7 +442,7 @@ std::vector<ClangPlugin::CCCallTip> ClangPlugin::GetCallTips(int pos, int style,
     while (--pos > 0)
     {
         if (   stc->GetCharAt(pos) <= wxT(' ')
-            || stc->IsComment(stc->GetStyleAt(pos)) )
+                || stc->IsComment(stc->GetStyleAt(pos)) )
         {
             continue;
         }
@@ -399,12 +456,22 @@ std::vector<ClangPlugin::CCCallTip> ClangPlugin::GetCallTips(int pos, int style,
         const int column = pos - stc->PositionFromLine(line);
         const wxString& tknText = stc->GetTextRange(stc->WordStartPosition(pos, true), argsPos);
         if (!tknText.IsEmpty())
-            m_Proxy.GetCallTipsAt(ed->GetFilename(), line + 1, column + 1,
-                                  m_TranslUnitId, tknText, m_LastCallTips);
+        {
+            ClangProxy::GetCallTipsAtTask task( cbEVT_CLANG_SYNCTASK_FINISHED, idClangSyncTask, ed->GetFilename(), line + 1, column + 1, m_TranslUnitId, tknText);
+            m_Proxy.AddPendingTask(task);
+            if( task.WaitCompletion(100) == wxCOND_TIMEOUT )
+            {
+                fprintf(stdout,"GetCallTips: Timeout\n");
+                return tips;
+            }
+            m_LastCallTips = task.GetResults();
+        }
+        //    m_Proxy.GetCallTipsAt(ed->GetFilename(), line + 1, column + 1,
+        //            m_TranslUnitId, tknText, m_LastCallTips);
     }
     m_LastCallTipPos = argsPos;
     for (std::vector<wxStringVec>::const_iterator strVecItr = m_LastCallTips.begin();
-         strVecItr != m_LastCallTips.end(); ++strVecItr)
+            strVecItr != m_LastCallTips.end(); ++strVecItr)
     {
         int strVecSz = strVecItr->size();
         if (commas != 0 && strVecSz < commas + 3)
@@ -431,22 +498,32 @@ std::vector<ClangPlugin::CCCallTip> ClangPlugin::GetCallTips(int pos, int style,
 
 std::vector<ClangPlugin::CCToken> ClangPlugin::GetTokenAt(int pos, cbEditor* ed, bool& allowCallTip)
 {
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     std::vector<CCToken> tokens;
+    if( m_Parsing > 0 )
+        return tokens;
     if (ed != m_pLastEditor)
     {
         m_TranslUnitId = m_Proxy.GetTranslationUnitId(ed->GetFilename());
         m_pLastEditor = ed;
     }
     if (m_TranslUnitId == wxNOT_FOUND)
+    {
+        wxCommandEvent evt(cbEVT_COMMAND_REPARSE, idReparse);
+        AddPendingEvent(evt);
         return tokens;
+    }
 
     cbStyledTextCtrl* stc = ed->GetControl();
     if (stc->GetTextRange(pos - 1, pos + 1).Strip().IsEmpty())
         return tokens;
     const int line = stc->LineFromPosition(pos);
     const int column = pos - stc->PositionFromLine(line);
-    wxStringVec names;
-    m_Proxy.GetTokensAt(ed->GetFilename(), line + 1, column + 1, m_TranslUnitId, names);
+
+    ClangProxy::GetTokensAtTask task( cbEVT_CLANG_SYNCTASK_FINISHED, idClangSyncTask, ed->GetFilename(), line + 1, column + 1, m_TranslUnitId);
+    task.WaitCompletion(3000);
+    wxStringVec names = task.GetResults();
+    //m_Proxy.GetTokensAt(ed->GetFilename(), line + 1, column + 1, m_TranslUnitId, names);
     for (wxStringVec::const_iterator nmIt = names.begin(); nmIt != names.end(); ++nmIt)
         tokens.push_back(CCToken(-1, *nmIt));
     return tokens;
@@ -454,11 +531,13 @@ std::vector<ClangPlugin::CCToken> ClangPlugin::GetTokenAt(int pos, cbEditor* ed,
 
 wxString ClangPlugin::OnDocumentationLink(wxHtmlLinkEvent& event, bool& dismissPopup)
 {
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     return wxEmptyString;
 }
 
 void ClangPlugin::DoAutocomplete(const CCToken& token, cbEditor* ed)
 {
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     wxString tknText = token.name;
     int idx = tknText.Find(wxT(':'));
     if (idx != wxNOT_FOUND)
@@ -466,13 +545,13 @@ void ClangPlugin::DoAutocomplete(const CCToken& token, cbEditor* ed)
     std::pair<int, int> offsets = std::make_pair(0, 0);
     cbStyledTextCtrl* stc = ed->GetControl();
     wxString suffix = m_Proxy.GetCCInsertSuffix(m_TranslUnitId, token.id,
-                                                  GetEOLStr(stc->GetEOLMode())
-                                                + ed->GetLineIndentString(stc->GetCurrentLine()),
-                                                offsets);
+            GetEOLStr(stc->GetEOLMode())
+            + ed->GetLineIndentString(stc->GetCurrentLine()),
+            offsets);
 
     int pos = stc->GetCurrentPos();
     int startPos = std::min(stc->WordStartPosition(pos, true), std::min(stc->GetSelectionStart(),
-                                                                        stc->GetSelectionEnd()));
+            stc->GetSelectionEnd()));
     int moveToPos = startPos + tknText.Length();
     stc->SetTargetStart(startPos);
     int endPos = stc->WordEndPosition(pos, true);
@@ -503,7 +582,7 @@ void ClangPlugin::DoAutocomplete(const CCToken& token, cbEditor* ed)
     stc->SetSelectionVoid(moveToPos + offsets.first, moveToPos + offsets.second);
     stc->ChooseCaretX();
     if (   token.category != tcLangKeyword
-        && (offsets.first != offsets.second || offsets.first == 1) )
+            && (offsets.first != offsets.second || offsets.first == 1) )
     {
         int tooltipMode = Manager::Get()->GetConfigManager(wxT("ccmanager"))->ReadInt(wxT("/tooltip_mode"), 1);
         if (tooltipMode != 3) // keybound only
@@ -519,12 +598,12 @@ void ClangPlugin::BuildMenu(wxMenuBar* menuBar)
     int idx = menuBar->FindMenu(_("Sea&rch"));
     if (idx != wxNOT_FOUND)
     {
-        menuBar->GetMenu(idx)->Append(idGotoDeclaration, _("Resolve token (clang)"));
+        menuBar->GetMenu(idx)->Append(idGotoDeclaration, _("Find declaration (clang)"));
     }
 }
 
 void ClangPlugin::BuildModuleMenu(const ModuleType type, wxMenu* menu,
-                                  const FileTreeData* WXUNUSED(data))
+        const FileTreeData* WXUNUSED(data))
 {
     if (type != mtEditorManager)
         return;
@@ -542,39 +621,112 @@ void ClangPlugin::BuildModuleMenu(const ModuleType type, wxMenu* menu,
     const int pos = stc->GetCurrentPos();
     if (stc->GetTextRange(pos - 1, pos + 1).Strip().IsEmpty())
         return;
-    menu->Insert(0, idGotoDeclaration, _("Resolve token (clang)"));
+    menu->Insert(0, idGotoDeclaration, _("Find declaration (clang)"));
 }
 
 void ClangPlugin::OnEditorOpen(CodeBlocksEvent& event)
 {
-    cbEditor* ed = Manager::Get()->GetEditorManager()->GetBuiltinEditor(event.GetEditor());
-    if (ed){
-        UpdateCompileCommand(ed);
-        m_EdOpenTimer.Start(ED_OPEN_DELAY, wxTIMER_ONE_SHOT);
-    }
     event.Skip();
+
+    cbEditor* ed = Manager::Get()->GetEditorManager()->GetBuiltinEditor(event.GetEditor());
+    if (ed)
+    {
+        int compileCommandChanged = UpdateCompileCommand(ed);
+        int translId = m_Proxy.GetTranslationUnitId(ed->GetFilename());
+        if( translId == wxNOT_FOUND)
+        {
+            wxCommandEvent evt(cbEVT_COMMAND_CREATETRANSLATIONUNIT,idCreateTranslationUnit);
+            AddPendingEvent(evt);
+            return;
+        }
+        if( compileCommandChanged || (translId != this->m_TranslUnitId) )
+        {
+            std::cout<<"EditorOpen: posting reparse (compile command changed or translId changed)"<<std::endl;
+            wxCommandEvent evt(cbEVT_COMMAND_REPARSE, idReparse);
+            AddPendingEvent(evt);
+        }
+    }
 }
 
 void ClangPlugin::OnEditorActivate(CodeBlocksEvent& event)
 {
-    cbEditor* ed = Manager::Get()->GetEditorManager()->GetBuiltinEditor(event.GetEditor());
-    if (ed ){
-        UpdateCompileCommand(ed);
-        if(!m_EdOpenTimer.IsRunning())
-            m_EdOpenTimer.Start(ED_ACTIVATE_DELAY, wxTIMER_ONE_SHOT);
-    }
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     event.Skip();
+    cbEditor* ed = Manager::Get()->GetEditorManager()->GetBuiltinEditor(event.GetEditor());
+    if (ed)
+    {
+        int reparseNeeded = UpdateCompileCommand(ed);
+        if( m_Parsing == 0 )
+        {
+            int translId = m_Proxy.GetTranslationUnitId(ed->GetFilename());
+            if( translId == wxNOT_FOUND)
+            {
+                std::cout<<"No translation unit for file "<<ed->GetFilename().c_str()<<std::endl;
+                wxCommandEvent evt(cbEVT_COMMAND_CREATETRANSLATIONUNIT,idCreateTranslationUnit);
+                AddPendingEvent(evt);
+                return;
+            }
+            if( translId != this->m_TranslUnitId )
+                reparseNeeded = 1;
+        }
+        if( reparseNeeded )
+        {
+            std::cout<<"OnEditorActivate: Calling reparse (compile command changed or translId changed)"<<std::endl;
+            wxCommandEvent evt(cbEVT_COMMAND_REPARSE, idReparse);
+            AddPendingEvent(evt);
+        }
+    }
+}
+
+void ClangPlugin::OnEditorSave(CodeBlocksEvent& /*event*/)
+{
+    wxCommandEvent evt(cbEVT_COMMAND_DIAGNOSEED, idDiagnoseEd);
+    AddPendingEvent(evt);
 }
 
 void ClangPlugin::OnProjectActivate(CodeBlocksEvent& event)
 {
-    cbEditor* ed = Manager::Get()->GetEditorManager()->GetBuiltinEditor(event.GetEditor());
-    if (ed){
-        UpdateCompileCommand(ed);
-        if (!m_EdOpenTimer.IsRunning())
-            m_EdOpenTimer.Start(ED_ACTIVATE_DELAY, wxTIMER_ONE_SHOT);
-    }
     event.Skip();
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+    cbEditor* ed = Manager::Get()->GetEditorManager()->GetBuiltinEditor(event.GetEditor());
+    if (ed)
+    {
+        int reparseNeeded = UpdateCompileCommand(ed);
+        if(m_Parsing == 0)
+        {
+            int translId = m_Proxy.GetTranslationUnitId(ed->GetFilename());
+            if( translId == wxNOT_FOUND)
+            {
+                wxCommandEvent evt(cbEVT_COMMAND_CREATETRANSLATIONUNIT,idCreateTranslationUnit);
+                AddPendingEvent(evt);
+                return;
+            }
+            if( translId != m_TranslUnitId )
+                reparseNeeded = 1;
+        }
+        if( reparseNeeded )
+        {
+            std::cout<<"OnProjectActivate: Calling reparse (compile command changed or translId changed)"<<std::endl;
+            wxCommandEvent evt(cbEVT_COMMAND_REPARSE, idReparse);
+            AddPendingEvent(evt);
+        }
+    }
+}
+
+void ClangPlugin::OnProjectOptionsChanged(CodeBlocksEvent& event)
+{
+    event.Skip();
+    cbEditor* ed = Manager::Get()->GetEditorManager()->GetBuiltinEditor(event.GetEditor());
+    if (ed)
+    {
+        int compileCommandChanged = UpdateCompileCommand(ed);
+        if( compileCommandChanged )
+        {
+            std::cout<<"OnProjectOptionsChanged: Calling reparse (compile command changed)"<<std::endl;
+            wxCommandEvent evt(cbEVT_COMMAND_REPARSE, idReparse);
+            AddPendingEvent(evt);
+        }
+    }
 }
 
 void ClangPlugin::OnGotoDeclaration(wxCommandEvent& WXUNUSED(event))
@@ -590,11 +742,11 @@ void ClangPlugin::OnGotoDeclaration(wxCommandEvent& WXUNUSED(event))
     if (stc->GetLine(line).StartsWith(wxT("#include")))
         column = 2;
     ++line;
-    m_Proxy.ResolveTokenAt(filename, line, column, m_TranslUnitId);
+    m_Proxy.ResolveDeclTokenAt(filename, line, column, m_TranslUnitId);
     ed = Manager::Get()->GetEditorManager()->Open(filename);
     if (ed)
         ed->GotoTokenPosition(line - 1, stc->GetTextRange(stc->WordStartPosition(pos, true),
-                                                          stc->WordEndPosition(pos, true)));
+                stc->WordEndPosition(pos, true)));
 }
 
 wxString ClangPlugin::GetCompilerInclDirs(const wxString& compId)
@@ -651,7 +803,7 @@ wxString ClangPlugin::GetSourceOf(cbEditor* ed)
     bool isCandidate;
     wxArrayString fileArray;
     wxDir::GetAllFiles(theFile.GetPath(wxPATH_GET_VOLUME), &fileArray,
-                       theFile.GetName() + wxT(".*"), wxDIR_FILES | wxDIR_HIDDEN);
+            theFile.GetName() + wxT(".*"), wxDIR_FILES | wxDIR_HIDDEN);
     wxFileName currentCandidateFile = FindSourceIn(fileArray, theFile, isCandidate);
     if (isCandidate)
         candidateFile = currentCandidateFile;
@@ -680,7 +832,7 @@ wxString ClangPlugin::GetSourceOf(cbEditor* ed)
     {
         fileArray.Clear();
         for (FilesList::const_iterator it = project->GetFilesList().begin();
-             it != project->GetFilesList().end(); ++it)
+                it != project->GetFilesList().end(); ++it)
         {
             ProjectFile* pf = *it;
             if (!pf)
@@ -730,7 +882,7 @@ wxString ClangPlugin::GetSourceOf(cbEditor* ed)
 }
 
 wxFileName ClangPlugin::FindSourceIn(const wxArrayString& candidateFilesArray,
-                                     const wxFileName& activeFile, bool& isCandidate)
+        const wxFileName& activeFile, bool& isCandidate)
 {
     bool extStartsWithCapital = wxIsupper(activeFile.GetExt()[0]);
     wxFileName candidateFile;
@@ -751,7 +903,7 @@ wxFileName ClangPlugin::FindSourceIn(const wxArrayString& candidateFilesArray,
 }
 
 bool ClangPlugin::IsSourceOf(const wxFileName& candidateFile,
-                             const wxFileName& activeFile, bool& isCandidate)
+        const wxFileName& activeFile, bool& isCandidate)
 {
     if (candidateFile.GetName().CmpNoCase(activeFile.GetName()) == 0)
     {
@@ -762,7 +914,7 @@ bool ClangPlugin::IsSourceOf(const wxFileName& candidateFile,
             {
                 wxArrayString fileArray;
                 wxDir::GetAllFiles(candidateFile.GetPath(wxPATH_GET_VOLUME), &fileArray,
-                                   candidateFile.GetName() + wxT(".*"), wxDIR_FILES | wxDIR_HIDDEN);
+                        candidateFile.GetName() + wxT(".*"), wxDIR_FILES | wxDIR_HIDDEN);
                 for (size_t i = 0; i < fileArray.GetCount(); ++i)
                     if (wxFileName(fileArray[i]).GetFullName() == activeFile.GetFullName())
                         return false;
@@ -773,10 +925,10 @@ bool ClangPlugin::IsSourceOf(const wxFileName& candidateFile,
     return false;
 }
 
-// Don't call this function from within:
+// Don't call this function from within the scope of:
 //      ClangPlugin::OnEditorHook
 //      ClangPlugin::OnTimer
-void ClangPlugin::UpdateCompileCommand(cbEditor* ed)
+int ClangPlugin::UpdateCompileCommand(cbEditor* ed)
 {
     wxString compileCommand;
     ProjectFile* pf = ed->GetProjectFile();
@@ -800,21 +952,21 @@ void ClangPlugin::UpdateCompileCommand(cbEditor* ed)
     if (!comp)
         comp = CompilerFactory::GetDefaultCompiler();
 
-    if( pf && (!pf->GetBuildTargets().IsEmpty()) ){
+    if ( pf && (!pf->GetBuildTargets().IsEmpty()) )
+    {
         target = pf->GetParentProject()->GetBuildTarget(pf->GetBuildTargets()[0]);
 
-        if (pf->GetUseCustomBuildCommand(target->GetCompilerID()))
-        {
+        if (pf->GetUseCustomBuildCommand(target->GetCompilerID() ) )
             compileCommand = pf->GetCustomBuildCommand(target->GetCompilerID()).AfterFirst(wxT(' '));
-        }
+
     }
 
     if (compileCommand.IsEmpty())
         compileCommand = wxT("$options $includes");
     CompilerCommandGenerator* gen = comp->GetCommandGenerator(proj);
-    if( gen )
+    if ( gen )
         gen->GenerateCommandLine(compileCommand, target, pf, ed->GetFilename(),
-                                                         g_InvalidStr, g_InvalidStr, g_InvalidStr );
+                g_InvalidStr, g_InvalidStr, g_InvalidStr );
     delete gen;
 
     wxStringTokenizer tokenizer(compileCommand);
@@ -833,90 +985,46 @@ void ClangPlugin::UpdateCompileCommand(cbEditor* ed)
         compileCommand += flag + wxT(" ");
     }
     compileCommand += GetCompilerInclDirs(comp->GetID());
-
-    m_CompileCommand = compileCommand;
+    if( compileCommand != m_CompileCommand )
+    {
+        m_CompileCommand = compileCommand;
+        return 1;
+    }
+    return 0;
 }
 
 void ClangPlugin::OnTimer(wxTimerEvent& event)
 {
-    if (!IsAttached()){
+    if (!IsAttached())
+    {
         return;
     }
     const int evId = event.GetId();
-    if (evId == idEdOpenTimer) // m_EdOpenTimer
-    {
-        if (m_CompileCommand.IsEmpty()){
-            m_EdOpenTimer.Start(ED_OPEN_DELAY, wxTIMER_ONE_SHOT); // retry later
-            return;
-        }
-        cbEditor* ed = Manager::Get()->GetEditorManager()->GetBuiltinActiveEditor();
-        if (!ed || !IsProviderFor(ed)){
-            return;
-        }
-        else if (m_Proxy.GetTranslationUnitId(ed->GetFilename()) != wxNOT_FOUND)
-        {
-            m_DiagnosticTimer.Start(DIAGNOSTIC_DELAY, wxTIMER_ONE_SHOT);
-            return;
-        }
 
-        if (FileTypeOf(ed->GetFilename()) == ftHeader) // try to find the associated source
-        {
-            const wxString& source = GetSourceOf(ed);
-            if (!source.IsEmpty())
-            {
-                m_Proxy.CreateTranslationUnit(source, m_CompileCommand);
-                if (m_Proxy.GetTranslationUnitId(ed->GetFilename()) != wxNOT_FOUND){
-                    return; // got it
-                }
-            }
-        }
-        m_Proxy.CreateTranslationUnit(ed->GetFilename(), m_CompileCommand);
-        m_DiagnosticTimer.Start(DIAGNOSTIC_DELAY, wxTIMER_ONE_SHOT);
-    }
-    else if (evId == idReparseTimer) // m_ReparseTimer
+    if (evId == idReparseTimer) // m_ReparseTimer
     {
-        EditorManager* edMgr = Manager::Get()->GetEditorManager();
-        cbEditor* ed = edMgr->GetBuiltinActiveEditor();
-        if (!ed){
-            return;
-        }
-        if (ed != m_pLastEditor)
-        {
-            m_TranslUnitId = m_Proxy.GetTranslationUnitId(ed->GetFilename());
-            m_pLastEditor = ed;
-        }
-        if (m_TranslUnitId == wxNOT_FOUND){
-            return;
-        }
-        std::map<wxString, wxString> unsavedFiles;
-        for (int i = 0; i < edMgr->GetEditorsCount(); ++i)
-        {
-            ed = edMgr->GetBuiltinEditor(i);
-            if (ed && ed->GetModified())
-                unsavedFiles.insert(std::make_pair(ed->GetFilename(), ed->GetControl()->GetText()));
-        }
-        m_Proxy.Reparse(m_TranslUnitId, unsavedFiles);
-        DiagnoseEd(m_pLastEditor, dlMinimal);
+        wxCommandEvent evt(cbEVT_COMMAND_REPARSE, idReparse);
+        AddPendingEvent(evt);
     }
-    // m_DiagnosticTimer, m_HightlightTime
-    else if (evId == idDiagnosticTimer || evId == idHightlightTimer)
+    else if (evId == idHightlightTimer)
     {
         cbEditor* ed = Manager::Get()->GetEditorManager()->GetBuiltinActiveEditor();
-        if (!ed){
+        if (!ed)
+        {
             return;
         }
         if (ed != m_pLastEditor)
         {
-            m_TranslUnitId = m_Proxy.GetTranslationUnitId(ed->GetFilename());
-            m_pLastEditor = ed;
-        }
-        if (m_TranslUnitId == wxNOT_FOUND){
             return;
         }
-        if (evId == idDiagnosticTimer)
-            DiagnoseEd(ed, dlFull);
-        else
-            HighlightOccurrences(ed);
+        //    m_TranslUnitId = m_Proxy.GetTranslationUnitId(ed->GetFilename());
+        //    m_pLastEditor = ed;
+        //}
+        if (m_TranslUnitId == wxNOT_FOUND)
+        {
+            return;
+        }
+        HighlightOccurrences(ed);
     }
     else
     {
@@ -924,17 +1032,147 @@ void ClangPlugin::OnTimer(wxTimerEvent& event)
     }
 }
 
+void ClangPlugin::OnCreateTranslationUnit( wxCommandEvent& evt )
+{
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+    cbEditor* ed = Manager::Get()->GetEditorManager()->GetBuiltinActiveEditor();
+    if( !ed )
+    {
+        std::cout<<"No editor..."<<std::endl;
+        return;
+    }
+    /*
+        if (FileTypeOf(ed->GetFilename()) == ftHeader) // try to find the associated source
+        {
+            const wxString& source = GetSourceOf(ed);
+            if (!source.IsEmpty())
+            {
+                ClangProxy::TaskCreateTranslationUnit task( idSetTranslationUnitId, source, m_CompileCommand );
+                m_Proxy.AddPendingTask(task);
+            }
+        }
+    */
+
+    //if( (m_TranslUnitId != wxNOT_FOUND)&&(m_Proxy.GetTranslationUnitId(ed->GetFilename()) == m_TranslUnitId) ){
+    if( m_Proxy.GetTranslationUnitId(ed->GetFilename()) != wxNOT_FOUND )
+    {
+        std::cout<<"Translation unit allready created :"<<m_TranslUnitId<<" file="<<ed->GetFilename().c_str()<<std::endl;
+        return;
+    }
+    m_Parsing++;
+    ClangProxy::CreateTranslationUnitTask task( cbEVT_CLANG_CREATETU_FINISHED, idClangCreateTU, ed->GetFilename(), m_CompileCommand );
+    m_Proxy.AddPendingTask(task);
+    //m_DiagnosticTimer.Start(DIAGNOSTIC_DELAY, wxTIMER_ONE_SHOT);
+    std::cout<<__PRETTY_FUNCTION__<<" done"<<std::endl;
+}
+
+void ClangPlugin::OnClangCreateTUFinished( wxEvent& event )
+{
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+    m_Parsing--;
+
+    cbEditor* ed = Manager::Get()->GetEditorManager()->GetBuiltinActiveEditor();
+    if( !ed )
+    {
+        return;
+    }
+
+    ClangProxy::CreateTranslationUnitTask* obj = static_cast<ClangProxy::CreateTranslationUnitTask*>(event.GetEventObject());
+    if( !obj )
+    {
+        return;
+    }
+    std::cout<<"Translation unit created: "<<obj->m_TranslationUnitId<<" file="<<obj->m_Filename.c_str()<<std::endl;
+    if( obj->m_Filename == ed->GetFilename() )
+    {
+        m_TranslUnitId = obj->m_TranslationUnitId;
+        m_pLastEditor = ed;
+        wxCommandEvent evt(cbEVT_COMMAND_DIAGNOSEED, idDiagnoseEd);
+        AddPendingEvent(evt);
+    }
+    std::cout<<"current translation unit: "<<m_TranslUnitId<<std::endl;
+
+}
+
+void ClangPlugin::OnReparse( wxCommandEvent& event )
+{
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+    EditorManager* edMgr = Manager::Get()->GetEditorManager();
+    cbEditor* ed = edMgr->GetBuiltinActiveEditor();
+    if (!ed)
+    {
+        std::cout<<"No editor..."<<std::endl;
+        return;
+    }
+
+    if (ed != m_pLastEditor)
+    {
+        m_TranslUnitId = m_Proxy.GetTranslationUnitId(ed->GetFilename());
+        m_pLastEditor = ed;
+        std::cout<<"Reparse: TranslUnitId set to "<<m_TranslUnitId<<std::endl;
+    }
+    if (m_TranslUnitId == wxNOT_FOUND)
+    {
+        m_TranslUnitId = m_Proxy.GetTranslationUnitId(ed->GetFilename());
+    }
+    if (m_TranslUnitId == wxNOT_FOUND)
+    {
+        std::cout<<"Translation unit not found: "<<m_TranslUnitId<<" file="<<ed->GetFilename().c_str()<<std::endl;
+        return;
+    }
+    std::cout<<"Reparsing with translUnitId "<<m_TranslUnitId<<std::endl;
+    std::map<wxString, wxString> unsavedFiles;
+    for (int i = 0; i < edMgr->GetEditorsCount(); ++i)
+    {
+        ed = edMgr->GetBuiltinEditor(i);
+        if (ed && ed->GetModified())
+            unsavedFiles.insert(std::make_pair(wxString(ed->GetFilename().c_str()), wxString(ed->GetControl()->GetText().c_str())));
+    }
+    //m_Proxy.Reparse(m_TranslUnitId, unsavedFiles);
+    m_Parsing++;
+    ClangProxy::ReparseTask task( cbEVT_CLANG_REPARSE_FINISHED, idClangReparse, m_TranslUnitId, unsavedFiles);
+    m_Proxy.AddPendingTask(task);
+}
+
+void ClangPlugin::OnClangReparseFinished( wxEvent& event )
+{
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+    //DiagnoseEd(m_pLastEditor, dlMinimal);
+    // TODO: This is probably double
+
+    m_Parsing--;
+
+    ClangProxy::ReparseTask* pTask = static_cast<ClangProxy::ReparseTask*>(event.GetEventObject());
+    if( pTask->m_TranslId != this->m_TranslUnitId )
+    {
+        std::cout<<" Reparse finished but another file was loaded"<<std::endl;
+        return;
+    }
+
+    std::cout<<"Calling DiagnoseEd"<<std::endl;
+    wxCommandEvent diagEvt(cbEVT_COMMAND_DIAGNOSEED, idDiagnoseEd);
+    AddPendingEvent(diagEvt);
+}
+
 void ClangPlugin::OnEditorHook(cbEditor* ed, wxScintillaEvent& event)
 {
+    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
     event.Skip();
     if (!IsProviderFor(ed))
         return;
+    cbStyledTextCtrl* stc = ed->GetControl();
     if (event.GetEventType() == wxEVT_SCI_MODIFIED)
     {
         if (event.GetModificationType() & (wxSCI_MOD_INSERTTEXT | wxSCI_MOD_DELETETEXT))
         {
+            m_ReparseTimer.Stop();
             m_ReparseTimer.Start(REPARSE_DELAY, wxTIMER_ONE_SHOT);
-            m_DiagnosticTimer.Start(DIAGNOSTIC_DELAY, wxTIMER_ONE_SHOT);
+            ///wxCommandEvent evt(cbEVT_COMMAND_REPARSE,idReparse);
+            //AddPendingEvent(evt);
+            //m_DiagnosticTimer.Stop();
+            //m_DiagnosticTimer.Start(DIAGNOSTIC_DELAY, wxTIMER_ONE_SHOT);
+
+            stc->IndicatorClearRange(0, stc->GetLength());
         }
     }
     else if (event.GetEventType() == wxEVT_SCI_UPDATEUI)
@@ -942,15 +1180,46 @@ void ClangPlugin::OnEditorHook(cbEditor* ed, wxScintillaEvent& event)
         if (event.GetUpdated() & wxSCI_UPDATE_SELECTION)
         {
             m_HightlightTimer.Stop();
+            stc->IndicatorClearRange(0, stc->GetLength());
             m_HightlightTimer.Start(HIGHTLIGHT_DELAY, wxTIMER_ONE_SHOT);
         }
     }
 }
 
-void ClangPlugin::DiagnoseEd(cbEditor* ed, DiagnosticLevel diagLv)
+void ClangPlugin::OnDiagnoseEd( wxCommandEvent& event )
 {
-    std::vector<ClDiagnostic> diagnostics;
-    m_Proxy.GetDiagnostics(m_TranslUnitId, diagnostics);
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+
+    if( m_Parsing > 0 )
+    {
+        std::cout<<"Still parsing"<<std::endl;
+        return;
+    }
+    std::cout<<"translUnitId: "<<m_TranslUnitId<<std::endl;
+
+    ClangProxy::GetDiagnosticsTask task( cbEVT_CLANG_GETDIAGNOSTICS_FINISHED, idClangGetDiagnostics, m_TranslUnitId );
+    m_Proxy.AddPendingTask(task);
+}
+
+void ClangPlugin::OnClangGetDiagnosticsFinished( wxEvent& event )
+{
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+    DiagnosticLevel diagLv = dlFull; // TODO
+    ClangProxy::GetDiagnosticsTask* pTask = static_cast<ClangProxy::GetDiagnosticsTask*>(event.GetEventObject());
+
+    EditorManager* edMgr = Manager::Get()->GetEditorManager();
+    cbEditor* ed = edMgr->GetBuiltinActiveEditor();
+    if (!ed)
+    {
+        std::cout<<"No editor..."<<std::endl;
+        return;
+    }
+    if( pTask->m_TranslId != m_TranslUnitId )
+    {
+        // No longer the current editor
+        std::cout<<"Diagnostics requested but another file was loaded..."<<std::endl;
+        return;
+    }
     cbStyledTextCtrl* stc = ed->GetControl();
     if (diagLv == dlFull)
         stc->AnnotationClearAll();
@@ -963,8 +1232,8 @@ void ClangPlugin::DiagnoseEd(cbEditor* ed, DiagnosticLevel diagLv)
     stc->SetIndicatorCurrent(errorIndicator);
     stc->IndicatorClearRange(0, stc->GetLength());
     const wxString& fileNm = ed->GetFilename();
-    for ( std::vector<ClDiagnostic>::const_iterator dgItr = diagnostics.begin();
-          dgItr != diagnostics.end(); ++dgItr )
+    for ( std::vector<ClDiagnostic>::const_iterator dgItr = pTask->m_Diagnostics.begin();
+            dgItr != pTask->m_Diagnostics.end(); ++dgItr )
     {
         //Manager::Get()->GetLogManager()->Log(dgItr->file + wxT(" ") + dgItr->message + F(wxT(" %d, %d"), dgItr->range.first, dgItr->range.second));
         if (dgItr->file != fileNm)
@@ -990,9 +1259,9 @@ void ClangPlugin::DiagnoseEd(cbEditor* ed, DiagnosticLevel diagLv)
         }
         if (dgItr->severity == sError)
             stc->SetIndicatorCurrent(errorIndicator);
-        else if (   dgItr != diagnostics.begin()
-                 && dgItr->line == (dgItr - 1)->line
-                 && dgItr->range.first <= (dgItr - 1)->range.second )
+        else if (   dgItr != pTask->m_Diagnostics.begin()
+                && dgItr->line == (dgItr - 1)->line
+                && dgItr->range.first <= (dgItr - 1)->range.second )
         {
             continue; // do not overwrite the last indicator
         }
@@ -1004,14 +1273,21 @@ void ClangPlugin::DiagnoseEd(cbEditor* ed, DiagnosticLevel diagLv)
         stc->AnnotationSetVisible(wxSCI_ANNOTATION_BOXED);
 }
 
+void ClangPlugin::OnClangSyncTaskFinished( wxEvent& event )
+{
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+    ClangProxy::SyncTask* pTask = static_cast<ClangProxy::CodeCompleteAtTask*>(event.GetEventObject());
+    // TODO
+    //pTask->Finalize();
+}
 void ClangPlugin::HighlightOccurrences(cbEditor* ed)
 {
     cbStyledTextCtrl* stc = ed->GetControl();
     int pos = stc->GetCurrentPos();
     const wxChar ch = stc->GetCharAt(pos);
     if (   pos > 0
-        && (wxIsspace(ch) || (ch != wxT('_') && wxIspunct(ch)))
-        && !wxIsspace(stc->GetCharAt(pos - 1)) )
+            && (wxIsspace(ch) || (ch != wxT('_') && wxIspunct(ch)))
+            && !wxIsspace(stc->GetCharAt(pos - 1)) )
     {
         --pos;
     }
@@ -1037,10 +1313,18 @@ void ClangPlugin::HighlightOccurrences(cbEditor* ed)
 
     const int line = stc->LineFromPosition(pos);
     const int column = pos - stc->PositionFromLine(line);
-    std::vector< std::pair<int, int> > occurrences;
-    m_Proxy.GetOccurrencesOf(ed->GetFilename(), line + 1, column + 1, m_TranslUnitId, occurrences);
+    ClangProxy::GetOccurrencesOfTask task(cbEVT_CLANG_SYNCTASK_FINISHED, idClangSyncTask, ed->GetFilename(), line + 1, column + 1, m_TranslUnitId);
+    m_Proxy.AddPendingTask(task);
+    if( task.WaitCompletion(100) == wxCOND_TIMEOUT )
+    {
+        return;
+    }
+    std::vector< std::pair<int, int> > occurrences = task.GetResults();
+
+    //std::vector< std::pair<int, int> > occurrences;
+    //m_Proxy.GetOccurrencesOf(ed->GetFilename(), line + 1, column + 1, m_TranslUnitId, occurrences);
     for (std::vector< std::pair<int, int> >::const_iterator tkn = occurrences.begin();
-         tkn != occurrences.end(); ++tkn)
+            tkn != occurrences.end(); ++tkn)
     {
         stc->IndicatorFillRange(tkn->first, tkn->second);
     }

--- a/clangplugin.h
+++ b/clangplugin.h
@@ -78,6 +78,8 @@ class ClangPlugin : public cbCodeCompletionPlugin
         void OnEditorOpen(CodeBlocksEvent& event);
         /// Start up parsing timers
         void OnEditorActivate(CodeBlocksEvent& event);
+        /// Make project-dependent setup
+        void OnProjectActivate(CodeBlocksEvent& event);
         /// Generic handler for various timers
         void OnTimer(wxTimerEvent& event);
         /// Start re-parse and highlight timers
@@ -101,6 +103,10 @@ class ClangPlugin : public cbCodeCompletionPlugin
          */
         void HighlightOccurrences(cbEditor* ed);
 
+private: // Internal utility functions
+        void UpdateCompileCommand(cbEditor* ed);
+private: // Members
+
         TokenDatabase m_Database;
         wxStringVec m_CppKeywords;
         ClangProxy m_Proxy;
@@ -115,6 +121,7 @@ class ClangPlugin : public cbCodeCompletionPlugin
         int m_EditorHookId;
         int m_LastCallTipPos;
         std::vector<wxStringVec> m_LastCallTips;
+        wxString m_CompileCommand;
 };
 
 #endif // CLANGPLUGIN_H

--- a/clangplugin.h
+++ b/clangplugin.h
@@ -10,118 +10,140 @@
 
 class ClangPlugin : public cbCodeCompletionPlugin
 {
-    public:
-        ClangPlugin();
-        virtual ~ClangPlugin();
+public:
+    ClangPlugin();
+    virtual ~ClangPlugin();
 
-        /*-- Public interface --*/
+    /*-- Public interface --*/
 
-        // Does this plugin handle code completion for the editor ed?
-        virtual CCProviderStatus GetProviderStatusFor(cbEditor* ed);
-        // Supply content for the autocompletion list.
-        virtual std::vector<CCToken> GetAutocompList(bool isAuto, cbEditor* ed, int& tknStart, int& tknEnd);
-        // Supply html formatted documentation for the passed token.
-        virtual wxString GetDocumentation(const CCToken& token);
-        // Supply content for the calltip at the specified location.
-        virtual std::vector<CCCallTip> GetCallTips(int pos, int style, cbEditor* ed, int& argsPos);
-        // Supply the definition of the token at the specified location.
-        virtual std::vector<CCToken> GetTokenAt(int pos, cbEditor* ed, bool& allowCallTip);
-        // Handle documentation link event.
-        virtual wxString OnDocumentationLink(wxHtmlLinkEvent& event, bool& dismissPopup);
-        // Callback for inserting the selected autocomplete entry into the editor.
-        virtual void DoAutocomplete(const CCToken& token, cbEditor* ed);
+    // Does this plugin handle code completion for the editor ed?
+    virtual CCProviderStatus GetProviderStatusFor(cbEditor* ed);
+    // Supply content for the autocompletion list.
+    virtual std::vector<CCToken> GetAutocompList(bool isAuto, cbEditor* ed, int& tknStart, int& tknEnd);
+    // Supply html formatted documentation for the passed token.
+    virtual wxString GetDocumentation(const CCToken& token);
+    // Supply content for the calltip at the specified location.
+    virtual std::vector<CCCallTip> GetCallTips(int pos, int style, cbEditor* ed, int& argsPos);
+    // Supply the definition of the token at the specified location.
+    virtual std::vector<CCToken> GetTokenAt(int pos, cbEditor* ed, bool& allowCallTip);
+    // Handle documentation link event.
+    virtual wxString OnDocumentationLink(wxHtmlLinkEvent& event, bool& dismissPopup);
+    // Callback for inserting the selected autocomplete entry into the editor.
+    virtual void DoAutocomplete(const CCToken& token, cbEditor* ed);
 
-        // Build menu bar
-        virtual void BuildMenu(wxMenuBar* menuBar);
-        // Build popup menu
-        virtual void BuildModuleMenu(const ModuleType type, wxMenu* menu, const FileTreeData* data = nullptr);
+    // Build menu bar
+    virtual void BuildMenu(wxMenuBar* menuBar);
+    // Build popup menu
+    virtual void BuildModuleMenu(const ModuleType type, wxMenu* menu, const FileTreeData* data = nullptr);
 
-    protected:
-        virtual void OnAttach();
-        virtual void OnRelease(bool appShutDown);
+protected:
+    virtual void OnAttach();
+    virtual void OnRelease(bool appShutDown);
 
-    private:
-        /**
-         * Compute the locations of STL headers for the given compiler (cached)
-         *
-         * @param compId The id of the compiler
-         * @return Include search flags pointing to said locations
-         */
-        wxString GetCompilerInclDirs(const wxString& compId);
-        /**
-         * Search for the source file associated with a given header
-         *
-         * @param ed The editor representing the header file
-         * @return Full path to presumed source file
-         */
-        wxString GetSourceOf(cbEditor* ed);
-        /**
-         * Find the most likely source file from a list, corresponding to a given header
-         *
-         * @param candidateFilesArray List of possibilities to check
-         * @param activeFile Header file to compare to
-         * @param[out] isCandidate Set to true if returned file may not be best match
-         * @return File determined to be source (or invalid)
-         */
-        wxFileName FindSourceIn(const wxArrayString& candidateFilesArray, const wxFileName& activeFile, bool& isCandidate);
-        /**
-         * Test if a candidate source file matches a header file
-         *
-         * @param candidateFile The potential source file
-         * @param activeFile The header file
-         * @param[out] isCandidate Set to true if match is not exact
-         * @return true if files match close enough
-         */
-        bool IsSourceOf(const wxFileName& candidateFile, const wxFileName& activeFile, bool& isCandidate);
+private:
+    /**
+     * Compute the locations of STL headers for the given compiler (cached)
+     *
+     * @param compId The id of the compiler
+     * @return Include search flags pointing to said locations
+     */
+    wxString GetCompilerInclDirs(const wxString& compId);
+    /**
+     * Search for the source file associated with a given header
+     *
+     * @param ed The editor representing the header file
+     * @return Full path to presumed source file
+     */
+    wxString GetSourceOf(cbEditor* ed);
+    /**
+     * Find the most likely source file from a list, corresponding to a given header
+     *
+     * @param candidateFilesArray List of possibilities to check
+     * @param activeFile Header file to compare to
+     * @param[out] isCandidate Set to true if returned file may not be best match
+     * @return File determined to be source (or invalid)
+     */
+    wxFileName FindSourceIn(const wxArrayString& candidateFilesArray, const wxFileName& activeFile, bool& isCandidate);
+    /**
+     * Test if a candidate source file matches a header file
+     *
+     * @param candidateFile The potential source file
+     * @param activeFile The header file
+     * @param[out] isCandidate Set to true if match is not exact
+     * @return true if files match close enough
+     */
+    bool IsSourceOf(const wxFileName& candidateFile, const wxFileName& activeFile, bool& isCandidate);
 
-        /// Start up parsing timers
-        void OnEditorOpen(CodeBlocksEvent& event);
-        /// Start up parsing timers
-        void OnEditorActivate(CodeBlocksEvent& event);
-        /// Make project-dependent setup
-        void OnProjectActivate(CodeBlocksEvent& event);
-        /// Generic handler for various timers
-        void OnTimer(wxTimerEvent& event);
-        /// Start re-parse and highlight timers
-        void OnEditorHook(cbEditor* ed, wxScintillaEvent& event);
-        /// Resolve the token under the cursor and open the relevant location
-        void OnGotoDeclaration(wxCommandEvent& event);
+    /// Start up parsing timers
+    void OnEditorOpen(CodeBlocksEvent& event);
+    /// Start up parsing timers
+    void OnEditorActivate(CodeBlocksEvent& event);
+    void OnEditorSave(CodeBlocksEvent& event);
+    /// Make project-dependent setup
+    void OnProjectActivate(CodeBlocksEvent& event);
+    /// Update project-dependent setup
+    void OnProjectOptionsChanged(CodeBlocksEvent& event);
+    /// Generic handler for various timers
+    void OnTimer(wxTimerEvent& event);
+    /// Start re-parse and highlight timers
+    void OnEditorHook(cbEditor* ed, wxScintillaEvent& event);
+    /// Resolve the token under the cursor and open the relevant location
+    void OnGotoDeclaration(wxCommandEvent& event);
+    /// Set the clang translation unit (callback)
+    void OnClangCreateTUFinished( wxEvent& event );
+    /// Update after clang has reparsing done (callback)
+    void OnClangReparseFinished( wxEvent& event );
+    /// Update after clang has built diagnostics
+    void OnClangGetDiagnosticsFinished( wxEvent& event );
+    /// Update after clang has finished a synchronous task
+    void OnClangSyncTaskFinished( wxEvent& event );
 
-        enum DiagnosticLevel { dlMinimal, dlFull };
-        /**
-         * Update editor diagnostic mark up
-         *
-         * @param ed The editor to diagnose
-         * @param diagLv Update only the highlights, or highlights and text annotations
-         */
-        void DiagnoseEd(cbEditor* ed, DiagnosticLevel diagLv);
-        /**
-         * Semantically highlight all occurrences of the token under the cursor
-         * within the editor
-         *
-         * @param ed The editor to work in
-         */
-        void HighlightOccurrences(cbEditor* ed);
+    enum DiagnosticLevel { dlMinimal, dlFull };
+    /**
+     * Update editor diagnostic mark up
+     *
+     * @param ed The editor to diagnose
+     * @param diagLv Update only the highlights, or highlights and text annotations
+     */
+    //void DiagnoseEd(cbEditor* ed, DiagnosticLevel diagLv);
+    void OnDiagnoseEd( wxCommandEvent& event );
+    /**
+     * Semantically highlight all occurrences of the token under the cursor
+     * within the editor
+     *
+     * @param ed The editor to work in
+     */
+    void HighlightOccurrences(cbEditor* ed);
 
 private: // Internal utility functions
-        void UpdateCompileCommand(cbEditor* ed);
+
+    // Builds compile command
+    int UpdateCompileCommand(cbEditor* ed);
+
+    // Async
+    void OnReparse( wxCommandEvent& evt );
+
+    // Async
+    void OnCreateTranslationUnit( wxCommandEvent& evt );
+
 private: // Members
 
-        TokenDatabase m_Database;
-        wxStringVec m_CppKeywords;
-        ClangProxy m_Proxy;
-        wxImageList m_ImageList;
-        wxTimer m_EdOpenTimer;
-        wxTimer m_ReparseTimer;
-        wxTimer m_DiagnosticTimer;
-        wxTimer m_HightlightTimer;
-        std::map<wxString, wxString> m_compInclDirs;
-        cbEditor* m_pLastEditor;
-        int m_TranslUnitId;
-        int m_EditorHookId;
-        int m_LastCallTipPos;
-        std::vector<wxStringVec> m_LastCallTips;
-        wxString m_CompileCommand;
+    TokenDatabase m_Database;
+    wxStringVec m_CppKeywords;
+    ClangProxy m_Proxy;
+    wxImageList m_ImageList;
+    //wxTimer m_EdOpenTimer;
+    wxTimer m_ReparseTimer;
+    wxTimer m_DiagnosticTimer;
+    wxTimer m_HightlightTimer;
+    std::map<wxString, wxString> m_compInclDirs;
+    cbEditor* m_pLastEditor;
+    int m_TranslUnitId;
+    int m_EditorHookId;
+    int m_LastCallTipPos;
+    std::vector<wxStringVec> m_LastCallTips;
+    wxString m_CompileCommand;
+    unsigned int m_Parsing;
 };
 
 #endif // CLANGPLUGIN_H

--- a/clangproxy.cpp
+++ b/clangproxy.cpp
@@ -9,7 +9,7 @@
 #include <wx/tokenzr.h>
 
 #ifndef CB_PRECOMP
-    #include <algorithm>
+#include <algorithm>
 #endif // CB_PRECOMP
 
 #include "tokendatabase.h"
@@ -17,539 +17,575 @@
 
 namespace ProxyHelper
 {
-    static TokenCategory GetTokenCategory(CXCursorKind kind, CX_CXXAccessSpecifier access = CX_CXXInvalidAccessSpecifier)
+static TokenCategory GetTokenCategory(CXCursorKind kind, CX_CXXAccessSpecifier access = CX_CXXInvalidAccessSpecifier)
+{
+    switch (kind)
     {
-        switch (kind)
+    case CXCursor_StructDecl:
+    case CXCursor_UnionDecl:
+    case CXCursor_ClassDecl:
+    case CXCursor_ClassTemplate:
+        switch (access)
         {
-            case CXCursor_StructDecl:
-            case CXCursor_UnionDecl:
-            case CXCursor_ClassDecl:
-            case CXCursor_ClassTemplate:
-                switch (access)
-                {
-                    case CX_CXXPublic:
-                        return tcClassPublic;
-                    case CX_CXXProtected:
-                        return tcClassProtected;
-                    case CX_CXXPrivate:
-                        return tcClassPrivate;
-                    default:
-                    case CX_CXXInvalidAccessSpecifier:
-                        return tcClass;
-                }
-
-            case CXCursor_Constructor:
-                switch (access)
-                {
-                    default:
-                    case CX_CXXInvalidAccessSpecifier:
-                    case CX_CXXPublic:
-                        return tcCtorPublic;
-                    case CX_CXXProtected:
-                        return tcCtorProtected;
-                    case CX_CXXPrivate:
-                        return tcCtorPrivate;
-                }
-
-            case CXCursor_Destructor:
-                switch (access)
-                {
-                    default:
-                    case CX_CXXInvalidAccessSpecifier:
-                    case CX_CXXPublic:
-                        return tcDtorPublic;
-                    case CX_CXXProtected:
-                        return tcDtorProtected;
-                    case CX_CXXPrivate:
-                        return tcDtorPrivate;
-                }
-
-            case CXCursor_FunctionDecl:
-            case CXCursor_CXXMethod:
-            case CXCursor_FunctionTemplate:
-                switch (access)
-                {
-                    default:
-                    case CX_CXXInvalidAccessSpecifier:
-                    case CX_CXXPublic:
-                        return tcFuncPublic;
-                    case CX_CXXProtected:
-                        return tcFuncProtected;
-                    case CX_CXXPrivate:
-                        return tcFuncPrivate;
-                }
-
-            case CXCursor_FieldDecl:
-            case CXCursor_VarDecl:
-            case CXCursor_ParmDecl:
-                switch (access)
-                {
-                    default:
-                    case CX_CXXInvalidAccessSpecifier:
-                    case CX_CXXPublic:
-                        return tcVarPublic;
-                    case CX_CXXProtected:
-                        return tcVarProtected;
-                    case CX_CXXPrivate:
-                        return tcVarPrivate;
-                }
-
-            case CXCursor_MacroDefinition:
-                return tcMacroDef;
-
-            case CXCursor_EnumDecl:
-                switch (access)
-                {
-                    case CX_CXXPublic:
-                        return tcEnumPublic;
-                    case CX_CXXProtected:
-                        return tcEnumProtected;
-                    case CX_CXXPrivate:
-                        return tcEnumPrivate;
-                    default:
-                    case CX_CXXInvalidAccessSpecifier:
-                        return tcEnum;
-                }
-
-            case CXCursor_EnumConstantDecl:
-                return tcEnumerator;
-
-            case CXCursor_Namespace:
-                return tcNamespace;
-
-            case CXCursor_TypedefDecl:
-                switch (access)
-                {
-                    case CX_CXXPublic:
-                        return tcTypedefPublic;
-                    case CX_CXXProtected:
-                        return tcTypedefProtected;
-                    case CX_CXXPrivate:
-                        return tcTypedefPrivate;
-                    default:
-                    case CX_CXXInvalidAccessSpecifier:
-                        return tcTypedef;
-                }
-
-            default:
-                return tcNone;
+        case CX_CXXPublic:
+            return tcClassPublic;
+        case CX_CXXProtected:
+            return tcClassProtected;
+        case CX_CXXPrivate:
+            return tcClassPrivate;
+        default:
+        case CX_CXXInvalidAccessSpecifier:
+            return tcClass;
         }
+
+    case CXCursor_Constructor:
+        switch (access)
+        {
+        default:
+        case CX_CXXInvalidAccessSpecifier:
+        case CX_CXXPublic:
+            return tcCtorPublic;
+        case CX_CXXProtected:
+            return tcCtorProtected;
+        case CX_CXXPrivate:
+            return tcCtorPrivate;
+        }
+
+    case CXCursor_Destructor:
+        switch (access)
+        {
+        default:
+        case CX_CXXInvalidAccessSpecifier:
+        case CX_CXXPublic:
+            return tcDtorPublic;
+        case CX_CXXProtected:
+            return tcDtorProtected;
+        case CX_CXXPrivate:
+            return tcDtorPrivate;
+        }
+
+    case CXCursor_FunctionDecl:
+    case CXCursor_CXXMethod:
+    case CXCursor_FunctionTemplate:
+        switch (access)
+        {
+        default:
+        case CX_CXXInvalidAccessSpecifier:
+        case CX_CXXPublic:
+            return tcFuncPublic;
+        case CX_CXXProtected:
+            return tcFuncProtected;
+        case CX_CXXPrivate:
+            return tcFuncPrivate;
+        }
+
+    case CXCursor_FieldDecl:
+    case CXCursor_VarDecl:
+    case CXCursor_ParmDecl:
+        switch (access)
+        {
+        default:
+        case CX_CXXInvalidAccessSpecifier:
+        case CX_CXXPublic:
+            return tcVarPublic;
+        case CX_CXXProtected:
+            return tcVarProtected;
+        case CX_CXXPrivate:
+            return tcVarPrivate;
+        }
+
+    case CXCursor_MacroDefinition:
+        return tcMacroDef;
+
+    case CXCursor_EnumDecl:
+        switch (access)
+        {
+        case CX_CXXPublic:
+            return tcEnumPublic;
+        case CX_CXXProtected:
+            return tcEnumProtected;
+        case CX_CXXPrivate:
+            return tcEnumPrivate;
+        default:
+        case CX_CXXInvalidAccessSpecifier:
+            return tcEnum;
+        }
+
+    case CXCursor_EnumConstantDecl:
+        return tcEnumerator;
+
+    case CXCursor_Namespace:
+        return tcNamespace;
+
+    case CXCursor_TypedefDecl:
+        switch (access)
+        {
+        case CX_CXXPublic:
+            return tcTypedefPublic;
+        case CX_CXXProtected:
+            return tcTypedefProtected;
+        case CX_CXXPrivate:
+            return tcTypedefPrivate;
+        default:
+        case CX_CXXInvalidAccessSpecifier:
+            return tcTypedef;
+        }
+
+    default:
+        return tcNone;
+    }
+}
+
+static CXChildVisitResult ClCallTipCtorAST_Visitor(CXCursor cursor,
+        CXCursor WXUNUSED(parent),
+        CXClientData client_data)
+{
+    switch (cursor.kind)
+    {
+    case CXCursor_Constructor:
+    {
+        std::vector<CXCursor>* tokenSet
+            = static_cast<std::vector<CXCursor>*>(client_data);
+        tokenSet->push_back(cursor);
+        break;
     }
 
-    static CXChildVisitResult ClCallTipCtorAST_Visitor(CXCursor cursor,
-                                                       CXCursor WXUNUSED(parent),
-                                                       CXClientData client_data)
+    case CXCursor_FunctionDecl:
+    case CXCursor_CXXMethod:
+    case CXCursor_FunctionTemplate:
     {
-        switch (cursor.kind)
+        CXString str = clang_getCursorSpelling(cursor);
+        if (strcmp(clang_getCString(str), "operator()") == 0)
         {
-            case CXCursor_Constructor:
-            {
-                std::vector<CXCursor>* tokenSet
-                    = static_cast<std::vector<CXCursor>*>(client_data);
-                tokenSet->push_back(cursor);
-                break;
-            }
-
-            case CXCursor_FunctionDecl:
-            case CXCursor_CXXMethod:
-            case CXCursor_FunctionTemplate:
-            {
-                CXString str = clang_getCursorSpelling(cursor);
-                if (strcmp(clang_getCString(str), "operator()") == 0)
-                {
-                    std::vector<CXCursor>* tokenSet
-                        = static_cast<std::vector<CXCursor>*>(client_data);
-                    tokenSet->push_back(cursor);
-                }
-                clang_disposeString(str);
-                break;
-            }
-
-            default:
-                break;
+            std::vector<CXCursor>* tokenSet
+                = static_cast<std::vector<CXCursor>*>(client_data);
+            tokenSet->push_back(cursor);
         }
-        return CXChildVisit_Continue;
-    }
-
-    static CXChildVisitResult ClInheritance_Visitor(CXCursor cursor,
-                                                    CXCursor WXUNUSED(parent),
-                                                    CXClientData client_data)
-    {
-        if (cursor.kind != CXCursor_CXXBaseSpecifier)
-            return CXChildVisit_Break;
-        CXString str = clang_getTypeSpelling(clang_getCursorType(cursor));
-        static_cast<wxStringVec*>(client_data)->push_back(wxString::FromUTF8(clang_getCString(str)));
         clang_disposeString(str);
-        return CXChildVisit_Continue;
+        break;
     }
 
-    static CXChildVisitResult ClEnum_Visitor(CXCursor cursor,
-                                             CXCursor WXUNUSED(parent),
-                                             CXClientData client_data)
-    {
-        if (cursor.kind != CXCursor_EnumConstantDecl)
-            return CXChildVisit_Break;
-        int* counts = static_cast<int*>(client_data);
-        long long val = clang_getEnumConstantDeclValue(cursor);
-        if (val > 0 && !((val - 1) & val)) // is power of 2
-            ++counts[0];
-        ++counts[1];
-        counts[2] = std::max(counts[2], static_cast<int>(val));
-        return CXChildVisit_Continue;
+    default:
+        break;
     }
+    return CXChildVisit_Continue;
+}
 
-    static void ResolveCursorDecl(CXCursor& token)
+static CXChildVisitResult ClInheritance_Visitor(CXCursor cursor,
+        CXCursor WXUNUSED(parent),
+        CXClientData client_data)
+{
+    if (cursor.kind != CXCursor_CXXBaseSpecifier)
+        return CXChildVisit_Break;
+    CXString str = clang_getTypeSpelling(clang_getCursorType(cursor));
+    static_cast<wxStringVec*>(client_data)->push_back(wxString::FromUTF8(clang_getCString(str)));
+    clang_disposeString(str);
+    return CXChildVisit_Continue;
+}
+
+static CXChildVisitResult ClEnum_Visitor(CXCursor cursor,
+        CXCursor WXUNUSED(parent),
+        CXClientData client_data)
+{
+    if (cursor.kind != CXCursor_EnumConstantDecl)
+        return CXChildVisit_Break;
+    int* counts = static_cast<int*>(client_data);
+    long long val = clang_getEnumConstantDeclValue(cursor);
+    if (val > 0 && !((val - 1) & val)) // is power of 2
+        ++counts[0];
+    ++counts[1];
+    counts[2] = std::max(counts[2], static_cast<int>(val));
+    return CXChildVisit_Continue;
+}
+
+static void ResolveCursorDecl(CXCursor& token)
+{
+    CXCursor resolve = clang_getCursorDefinition(token);
+    if (clang_Cursor_isNull(resolve) || clang_isInvalid(token.kind))
     {
-        CXCursor resolve = clang_getCursorDefinition(token);
-        if (clang_Cursor_isNull(resolve) || clang_isInvalid(token.kind))
-        {
-            resolve = clang_getCursorReferenced(token);
-            if (!clang_Cursor_isNull(resolve) && !clang_isInvalid(token.kind))
-                token = resolve;
-        }
-        else
+        resolve = clang_getCursorReferenced(token);
+        if (!clang_Cursor_isNull(resolve) && !clang_isInvalid(token.kind))
             token = resolve;
     }
+    else
+        token = resolve;
+}
 
-    static CXVisitorResult ReferencesVisitor(CXClientData context,
-                                             CXCursor WXUNUSED(cursor),
-                                             CXSourceRange range)
+static void ResolveCursorImpl(CXCursor& token)
+{
+    CXCursor resolve = clang_getCursorReferenced(token);
+    if (clang_Cursor_isNull(resolve) || clang_isInvalid(token.kind))
     {
-        unsigned rgStart, rgEnd;
-        CXSourceLocation rgLoc = clang_getRangeStart(range);
-        clang_getSpellingLocation(rgLoc, nullptr, nullptr, nullptr, &rgStart);
-        rgLoc = clang_getRangeEnd(range);
-        clang_getSpellingLocation(rgLoc, nullptr, nullptr, nullptr, &rgEnd);
-        if (rgStart != rgEnd)
-        {
-            static_cast<std::vector< std::pair<int, int> >*>(context)
-                ->push_back(std::make_pair<int, int>(rgStart, rgEnd - rgStart));
-        }
-        return CXVisit_Continue;
+        resolve = clang_getCursorDefinition(token);
+        if (!clang_Cursor_isNull(resolve) && !clang_isInvalid(token.kind))
+            token = resolve;
     }
+    else
+        token = resolve;
+}
 
-    static wxString GetEnumValStr(CXCursor token)
+static CXVisitorResult ReferencesVisitor(CXClientData context,
+        CXCursor WXUNUSED(cursor),
+        CXSourceRange range)
+{
+    unsigned rgStart, rgEnd;
+    CXSourceLocation rgLoc = clang_getRangeStart(range);
+    clang_getSpellingLocation(rgLoc, nullptr, nullptr, nullptr, &rgStart);
+    rgLoc = clang_getRangeEnd(range);
+    clang_getSpellingLocation(rgLoc, nullptr, nullptr, nullptr, &rgEnd);
+    if (rgStart != rgEnd)
     {
-        int counts[] = {0, 0, 0}; // (numPowerOf2, numTotal, maxVal)
-        clang_visitChildren(clang_getCursorSemanticParent(token), &ProxyHelper::ClEnum_Visitor, counts);
-        wxLongLong val(clang_getEnumConstantDeclValue(token));
-        if ((   (counts[0] == counts[1])
-             || (counts[1] > 5 && counts[0] * 2 >= counts[1]) ) && val >= 0)
-        {
-            // lots of 2^n enum constants, probably bitmask -> display in hexadecimal
-            wxString formatStr
-                = wxString::Format(wxT("0x%%0%ulX"),
-                                   wxString::Format(wxT("%X"), // count max width for 0-padding
-                                                    static_cast<unsigned>(counts[2])).Length());
-            return wxString::Format(formatStr, static_cast<unsigned long>(val.GetValue()));
-        }
-        else
-            return val.ToString();
+        static_cast<std::vector< std::pair<int, int> >*>(context)
+        ->push_back(std::make_pair<int, int>(rgStart, rgEnd - rgStart));
     }
+    return CXVisit_Continue;
+}
+
+static wxString GetEnumValStr(CXCursor token)
+{
+    int counts[] = {0, 0, 0}; // (numPowerOf2, numTotal, maxVal)
+    clang_visitChildren(clang_getCursorSemanticParent(token), &ProxyHelper::ClEnum_Visitor, counts);
+    wxLongLong val(clang_getEnumConstantDeclValue(token));
+    if ((   (counts[0] == counts[1])
+            || (counts[1] > 5 && counts[0] * 2 >= counts[1]) ) && val >= 0)
+    {
+        // lots of 2^n enum constants, probably bitmask -> display in hexadecimal
+        wxString formatStr
+            = wxString::Format(wxT("0x%%0%ulX"),
+                    wxString::Format(wxT("%X"), // count max width for 0-padding
+                            static_cast<unsigned>(counts[2])).Length());
+        return wxString::Format(formatStr, static_cast<unsigned long>(val.GetValue()));
+    }
+    else
+        return val.ToString();
+}
 }
 
 namespace HTML_Writer
 {
-    static wxString Escape(const wxString& text)
+static wxString Escape(const wxString& text)
+{
+    wxString html;
+    html.reserve(text.size());
+    for (wxString::const_iterator itr = text.begin();
+            itr != text.end(); ++itr)
     {
-        wxString html;
-        html.reserve(text.size());
-        for (wxString::const_iterator itr = text.begin();
-             itr != text.end(); ++itr)
+        switch (*itr)
         {
-            switch (*itr)
-            {
-                case wxT('&'):  html += wxT("&amp;");  break;
-                case wxT('\"'): html += wxT("&quot;"); break;
-                case wxT('\''): html += wxT("&apos;"); break;
-                case wxT('<'):  html += wxT("&lt;");   break;
-                case wxT('>'):  html += wxT("&gt;");   break;
-                case wxT('\n'): html += wxT("<br>");   break;
-                default:        html += *itr;          break;
-            }
+        case wxT('&'):
+            html += wxT("&amp;");
+            break;
+        case wxT('\"'):
+            html += wxT("&quot;");
+            break;
+        case wxT('\''):
+            html += wxT("&apos;");
+            break;
+        case wxT('<'):
+            html += wxT("&lt;");
+            break;
+        case wxT('>'):
+            html += wxT("&gt;");
+            break;
+        case wxT('\n'):
+            html += wxT("<br>");
+            break;
+        default:
+            html += *itr;
+            break;
         }
-        return html;
     }
+    return html;
+}
 
-    static wxString Colourise(const wxString& text, const wxString& colour)
-    {
-        return wxT("<font color=\"") + colour + wxT("\">") + text + wxT("</font>");
-    }
+static wxString Colourise(const wxString& text, const wxString& colour)
+{
+    return wxT("<font color=\"") + colour + wxT("\">") + text + wxT("</font>");
+}
 
-    static wxString SyntaxHl(const wxString& code, const std::vector<wxString>& cppKeywords) // C++ style (ish)
+static wxString SyntaxHl(const wxString& code, const std::vector<wxString>& cppKeywords) // C++ style (ish)
+{
+    wxString html;
+    html.reserve(code.size());
+    int stRg = 0;
+    int style = wxSCI_C_DEFAULT;
+    const int codeLen = code.Length();
+    for (int enRg = 0; enRg <= codeLen; ++enRg)
     {
-        wxString html;
-        html.reserve(code.size());
-        int stRg = 0;
-        int style = wxSCI_C_DEFAULT;
-        const int codeLen = code.Length();
-        for (int enRg = 0; enRg <= codeLen; ++enRg)
+        wxChar ch = (enRg < codeLen ? code[enRg] : wxT('\0'));
+        wxChar nextCh = (enRg < codeLen - 1 ? code[enRg + 1] : wxT('\0'));
+        switch (style)
         {
-            wxChar ch = (enRg < codeLen ? code[enRg] : wxT('\0'));
-            wxChar nextCh = (enRg < codeLen - 1 ? code[enRg + 1] : wxT('\0'));
-            switch (style)
+        default:
+        case wxSCI_C_DEFAULT:
+        {
+            if (wxIsalpha(ch) || ch == wxT('_'))
+                style = wxSCI_C_IDENTIFIER;
+            else if (wxIsdigit(ch))
+                style = wxSCI_C_NUMBER;
+            else if (ch == wxT('"'))
+                style = wxSCI_C_STRING;
+            else if (ch == wxT('\''))
+                style = wxSCI_C_CHARACTER;
+            else if (ch == wxT('/') && nextCh == wxT('/'))
+                style = wxSCI_C_COMMENTLINE;
+            else if (wxIspunct(ch))
+                style = wxSCI_C_OPERATOR;
+            else
+                break;
+            if (stRg != enRg)
             {
-                default:
-                case wxSCI_C_DEFAULT:
-                {
-                    if (wxIsalpha(ch) || ch == wxT('_'))
-                        style = wxSCI_C_IDENTIFIER;
-                    else if (wxIsdigit(ch))
-                        style = wxSCI_C_NUMBER;
-                    else if (ch == wxT('"'))
-                        style = wxSCI_C_STRING;
-                    else if (ch == wxT('\''))
-                        style = wxSCI_C_CHARACTER;
-                    else if (ch == wxT('/') && nextCh == wxT('/'))
-                        style = wxSCI_C_COMMENTLINE;
-                    else if (wxIspunct(ch))
-                        style = wxSCI_C_OPERATOR;
-                    else
-                        break;
-                    if (stRg != enRg)
-                    {
-                        html += Escape(code.Mid(stRg, enRg - stRg));
-                        stRg = enRg;
-                    }
-                    break;
-                }
-
-                case wxSCI_C_IDENTIFIER:
-                {
-                    if (wxIsalnum(ch) || ch == wxT('_'))
-                        break;
-                    if (stRg != enRg)
-                    {
-                        const wxString& tkn = code.Mid(stRg, enRg - stRg);
-                        if (std::binary_search(cppKeywords.begin(), cppKeywords.end(), tkn))
-                            html += wxT("<b>") + Colourise(Escape(tkn), wxT("#00008b")) + wxT("</b>"); // DarkBlue
-                        else
-                            html += Escape(tkn);
-                        stRg = enRg;
-                        --enRg;
-                    }
-                    style = wxSCI_C_DEFAULT;
-                    break;
-                }
-
-                case wxSCI_C_NUMBER:
-                {
-                    if (wxIsalnum(ch))
-                        break;
-                    if (stRg != enRg)
-                    {
-                        html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("Magenta"));
-                        stRg = enRg;
-                        --enRg;
-                    }
-                    style = wxSCI_C_DEFAULT;
-                    break;
-                }
-
-                case wxSCI_C_STRING:
-                {
-                    if (ch == wxT('\\'))
-                    {
-                        if (nextCh != wxT('\n'))
-                            ++enRg;
-                        break;
-                    }
-                    else if (ch && ch != wxT('"') && ch != wxT('\n'))
-                        break;
-                    if (stRg != enRg)
-                    {
-                        if (ch == wxT('"'))
-                            ++enRg;
-                        html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("#0000cd")); // MediumBlue
-                        stRg = enRg;
-                        --enRg;
-                    }
-                    style = wxSCI_C_DEFAULT;
-                    break;
-                }
-
-                case wxSCI_C_CHARACTER:
-                {
-                    if (ch == wxT('\\'))
-                    {
-                        if (nextCh != wxT('\n'))
-                            ++enRg;
-                        break;
-                    }
-                    else if (ch && ch != wxT('\'') && ch != wxT('\n'))
-                        break;
-                    if (stRg != enRg)
-                    {
-                        if (ch == wxT('\''))
-                            ++enRg;
-                        html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("GoldenRod"));
-                        stRg = enRg;
-                        --enRg;
-                    }
-                    style = wxSCI_C_DEFAULT;
-                    break;
-                }
-
-                case wxSCI_C_COMMENTLINE:
-                {
-                    if (ch && ch != wxT('\n'))
-                        break;
-                    if (stRg != enRg)
-                    {
-                        html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("#778899")); // LightSlateGray
-                        stRg = enRg;
-                    }
-                    style = wxSCI_C_DEFAULT;
-                    break;
-                }
-
-                case wxSCI_C_OPERATOR:
-                {
-                    if (wxIspunct(ch) && ch != wxT('"') && ch != wxT('\'') && ch != wxT('_'))
-                        break;
-                    if (stRg != enRg)
-                    {
-                        html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("Red"));
-                        stRg = enRg;
-                        --enRg;
-                    }
-                    style = wxSCI_C_DEFAULT;
-                    break;
-                }
+                html += Escape(code.Mid(stRg, enRg - stRg));
+                stRg = enRg;
             }
+            break;
         }
-        return html;
-    }
 
-    static void FormatDocumentation(CXComment comment, wxString& doc, const std::vector<wxString>& cppKeywords)
-    {
-        size_t numChildren = clang_Comment_getNumChildren(comment);
-        for (size_t childIdx = 0; childIdx < numChildren; ++childIdx)
+        case wxSCI_C_IDENTIFIER:
         {
-            CXComment cmt = clang_Comment_getChild(comment, childIdx);
-            switch (clang_Comment_getKind(cmt))
+            if (wxIsalnum(ch) || ch == wxT('_'))
+                break;
+            if (stRg != enRg)
             {
-                case CXComment_Null:
-                    break;
+                const wxString& tkn = code.Mid(stRg, enRg - stRg);
+                if (std::binary_search(cppKeywords.begin(), cppKeywords.end(), tkn))
+                    html += wxT("<b>") + Colourise(Escape(tkn), wxT("#00008b")) + wxT("</b>"); // DarkBlue
+                else
+                    html += Escape(tkn);
+                stRg = enRg;
+                --enRg;
+            }
+            style = wxSCI_C_DEFAULT;
+            break;
+        }
 
-                case CXComment_Text:
+        case wxSCI_C_NUMBER:
+        {
+            if (wxIsalnum(ch))
+                break;
+            if (stRg != enRg)
+            {
+                html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("Magenta"));
+                stRg = enRg;
+                --enRg;
+            }
+            style = wxSCI_C_DEFAULT;
+            break;
+        }
+
+        case wxSCI_C_STRING:
+        {
+            if (ch == wxT('\\'))
+            {
+                if (nextCh != wxT('\n'))
+                    ++enRg;
+                break;
+            }
+            else if (ch && ch != wxT('"') && ch != wxT('\n'))
+                break;
+            if (stRg != enRg)
+            {
+                if (ch == wxT('"'))
+                    ++enRg;
+                html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("#0000cd")); // MediumBlue
+                stRg = enRg;
+                --enRg;
+            }
+            style = wxSCI_C_DEFAULT;
+            break;
+        }
+
+        case wxSCI_C_CHARACTER:
+        {
+            if (ch == wxT('\\'))
+            {
+                if (nextCh != wxT('\n'))
+                    ++enRg;
+                break;
+            }
+            else if (ch && ch != wxT('\'') && ch != wxT('\n'))
+                break;
+            if (stRg != enRg)
+            {
+                if (ch == wxT('\''))
+                    ++enRg;
+                html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("GoldenRod"));
+                stRg = enRg;
+                --enRg;
+            }
+            style = wxSCI_C_DEFAULT;
+            break;
+        }
+
+        case wxSCI_C_COMMENTLINE:
+        {
+            if (ch && ch != wxT('\n'))
+                break;
+            if (stRg != enRg)
+            {
+                html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("#778899")); // LightSlateGray
+                stRg = enRg;
+            }
+            style = wxSCI_C_DEFAULT;
+            break;
+        }
+
+        case wxSCI_C_OPERATOR:
+        {
+            if (wxIspunct(ch) && ch != wxT('"') && ch != wxT('\'') && ch != wxT('_'))
+                break;
+            if (stRg != enRg)
+            {
+                html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("Red"));
+                stRg = enRg;
+                --enRg;
+            }
+            style = wxSCI_C_DEFAULT;
+            break;
+        }
+        }
+    }
+    return html;
+}
+
+static void FormatDocumentation(CXComment comment, wxString& doc, const std::vector<wxString>& cppKeywords)
+{
+    size_t numChildren = clang_Comment_getNumChildren(comment);
+    for (size_t childIdx = 0; childIdx < numChildren; ++childIdx)
+    {
+        CXComment cmt = clang_Comment_getChild(comment, childIdx);
+        switch (clang_Comment_getKind(cmt))
+        {
+        case CXComment_Null:
+            break;
+
+        case CXComment_Text:
+        {
+            CXString str = clang_TextComment_getText(cmt);
+            doc += Escape(wxString::FromUTF8(clang_getCString(str)));
+            clang_disposeString(str);
+            break;
+        }
+
+        case CXComment_InlineCommand:
+        {
+            size_t numArgs = clang_InlineCommandComment_getNumArgs(cmt);
+            wxString argText;
+            for (size_t argIdx = 0; argIdx < numArgs; ++argIdx)
+            {
+                CXString str = clang_InlineCommandComment_getArgText(cmt, argIdx);
+                argText += Escape(wxString::FromUTF8(clang_getCString(str)));
+                clang_disposeString(str);
+            }
+            switch (clang_InlineCommandComment_getRenderKind(cmt))
+            {
+            default:
+            case CXCommentInlineCommandRenderKind_Normal:
+                doc += argText;
+                break;
+
+            case CXCommentInlineCommandRenderKind_Bold:
+                doc += wxT("<b>") + argText + wxT("</b>");
+                break;
+
+            case CXCommentInlineCommandRenderKind_Monospaced:
+                doc += wxT("<tt>") + argText + wxT("</tt>");
+                break;
+
+            case CXCommentInlineCommandRenderKind_Emphasized:
+                doc += wxT("<em>") + argText + wxT("</em>");
+                break;
+            }
+            break;
+        }
+
+        case CXComment_HTMLStartTag:
+        case CXComment_HTMLEndTag:
+        {
+            CXString str = clang_HTMLTagComment_getAsString(cmt);
+            doc += wxString::FromUTF8(clang_getCString(str));
+            clang_disposeString(str);
+            break;
+        }
+
+        case CXComment_Paragraph:
+            if (!clang_Comment_isWhitespace(cmt))
+            {
+                doc += wxT("<p>");
+                FormatDocumentation(cmt, doc, cppKeywords);
+                doc += wxT("</p>");
+            }
+            break;
+
+        case CXComment_BlockCommand: // TODO: follow the command's instructions
+            FormatDocumentation(cmt, doc, cppKeywords);
+            break;
+
+        case CXComment_ParamCommand:  // TODO
+        case CXComment_TParamCommand: // TODO
+            break;
+
+        case CXComment_VerbatimBlockCommand:
+            doc += wxT("<table cellspacing=\"0\" cellpadding=\"1\" bgcolor=\"black\" width=\"100%\"><tr><td>"
+                    "<table bgcolor=\"white\" width=\"100%\"><tr><td><pre>");
+            FormatDocumentation(cmt, doc, cppKeywords);
+            doc += wxT("</pre></td></tr></table></td></tr></table>");
+            break;
+
+        case CXComment_VerbatimBlockLine:
+        {
+            CXString str = clang_VerbatimBlockLineComment_getText(cmt);
+            wxString codeLine = wxString::FromUTF8(clang_getCString(str));
+            clang_disposeString(str);
+            int endIdx = codeLine.Find(wxT("*/")); // clang will throw in the rest of the file when this happens
+            if (endIdx != wxNOT_FOUND)
+            {
+                endIdx = codeLine.Truncate(endIdx).Find(wxT("\\endcode")); // try to save a bit of grace, and recover what we can
+                if (endIdx == wxNOT_FOUND)
                 {
-                    CXString str = clang_TextComment_getText(cmt);
-                    doc += Escape(wxString::FromUTF8(clang_getCString(str)));
-                    clang_disposeString(str);
-                    break;
-                }
-
-                case CXComment_InlineCommand:
-                {
-                    size_t numArgs = clang_InlineCommandComment_getNumArgs(cmt);
-                    wxString argText;
-                    for (size_t argIdx = 0; argIdx < numArgs; ++argIdx)
-                    {
-                        CXString str = clang_InlineCommandComment_getArgText(cmt, argIdx);
-                        argText += Escape(wxString::FromUTF8(clang_getCString(str)));
-                        clang_disposeString(str);
-                    }
-                    switch (clang_InlineCommandComment_getRenderKind(cmt))
-                    {
-                        default:
-                        case CXCommentInlineCommandRenderKind_Normal:
-                            doc += argText;
-                            break;
-
-                        case CXCommentInlineCommandRenderKind_Bold:
-                            doc += wxT("<b>") + argText + wxT("</b>");
-                            break;
-
-                        case CXCommentInlineCommandRenderKind_Monospaced:
-                            doc += wxT("<tt>") + argText + wxT("</tt>");
-                            break;
-
-                        case CXCommentInlineCommandRenderKind_Emphasized:
-                            doc += wxT("<em>") + argText + wxT("</em>");
-                            break;
-                    }
-                    break;
-                }
-
-                case CXComment_HTMLStartTag:
-                case CXComment_HTMLEndTag:
-                {
-                    CXString str = clang_HTMLTagComment_getAsString(cmt);
-                    doc += wxString::FromUTF8(clang_getCString(str));
-                    clang_disposeString(str);
-                    break;
-                }
-
-                case CXComment_Paragraph:
-                    if (!clang_Comment_isWhitespace(cmt))
-                    {
-                        doc += wxT("<p>");
-                        FormatDocumentation(cmt, doc, cppKeywords);
-                        doc += wxT("</p>");
-                    }
-                    break;
-
-                case CXComment_BlockCommand: // TODO: follow the command's instructions
-                    FormatDocumentation(cmt, doc, cppKeywords);
-                    break;
-
-                case CXComment_ParamCommand:  // TODO
-                case CXComment_TParamCommand: // TODO
-                    break;
-
-                case CXComment_VerbatimBlockCommand:
-                    doc += wxT("<table cellspacing=\"0\" cellpadding=\"1\" bgcolor=\"black\" width=\"100%\"><tr><td>"
-                               "<table bgcolor=\"white\" width=\"100%\"><tr><td><pre>");
-                    FormatDocumentation(cmt, doc, cppKeywords);
-                    doc += wxT("</pre></td></tr></table></td></tr></table>");
-                    break;
-
-                case CXComment_VerbatimBlockLine:
-                {
-                    CXString str = clang_VerbatimBlockLineComment_getText(cmt);
-                    wxString codeLine = wxString::FromUTF8(clang_getCString(str));
-                    clang_disposeString(str);
-                    int endIdx = codeLine.Find(wxT("*/")); // clang will throw in the rest of the file when this happens
+                    endIdx = codeLine.Find(wxT("@endcode"));
                     if (endIdx != wxNOT_FOUND)
-                    {
-                        endIdx = codeLine.Truncate(endIdx).Find(wxT("\\endcode")); // try to save a bit of grace, and recover what we can
-                        if (endIdx == wxNOT_FOUND)
-                        {
-                            endIdx = codeLine.Find(wxT("@endcode"));
-                            if (endIdx != wxNOT_FOUND)
-                                codeLine.Truncate(endIdx);
-                        }
-                        else
-                            codeLine.Truncate(endIdx);
-                        doc += SyntaxHl(codeLine, cppKeywords) + wxT("<br><font color=\"red\"><em>__clang_doxygen_parsing_error__</em></font><br>");
-                        return; // abort
-                    }
-                    doc += SyntaxHl(codeLine, cppKeywords) + wxT("<br>");
-                    break;
+                        codeLine.Truncate(endIdx);
                 }
-
-                case CXComment_VerbatimLine:
-                {
-                    CXString str = clang_VerbatimLineComment_getText(cmt);
-                    doc += wxT("<pre>") + Escape(wxString::FromUTF8(clang_getCString(str))) + wxT("</pre>"); // TODO: syntax highlight
-                    clang_disposeString(str);
-                    break;
-                }
-
-                case CXComment_FullComment: // ignore?
-                default:
-                    break;
+                else
+                    codeLine.Truncate(endIdx);
+                doc += SyntaxHl(codeLine, cppKeywords) + wxT("<br><font color=\"red\"><em>__clang_doxygen_parsing_error__</em></font><br>");
+                return; // abort
             }
+            doc += SyntaxHl(codeLine, cppKeywords) + wxT("<br>");
+            break;
+        }
+
+        case CXComment_VerbatimLine:
+        {
+            CXString str = clang_VerbatimLineComment_getText(cmt);
+            doc += wxT("<pre>") + Escape(wxString::FromUTF8(clang_getCString(str))) + wxT("</pre>"); // TODO: syntax highlight
+            clang_disposeString(str);
+            break;
+        }
+
+        case CXComment_FullComment: // ignore?
+        default:
+            break;
         }
     }
 }
+}
 
-ClangProxy::ClangProxy(TokenDatabase& database, const std::vector<wxString>& cppKeywords):
+ClangProxy::ClangProxy( wxEvtHandler* pEvtCallbackHandler, TokenDatabase& database, const std::vector<wxString>& cppKeywords):
+    m_Mutex(),
     m_Database(database),
-    m_CppKeywords(cppKeywords)
+    m_CppKeywords(cppKeywords),
+    m_TaskQueueMutex(),
+    m_pEventCallbackHandler(pEvtCallbackHandler),
+    m_ConditionQueueNotEmpty(m_TaskQueueMutex)
 {
     m_ClIndex = clang_createIndex(0, 0);
+#if CLANGPROXY_USE_THREAD
+    m_pThread = new TaskThread(this);
+    m_pThread->Create();
+    m_pThread->Run();
+#endif
 }
 
 ClangProxy::~ClangProxy()
@@ -560,6 +596,7 @@ ClangProxy::~ClangProxy()
 
 void ClangProxy::CreateTranslationUnit(const wxString& filename, const wxString& commands)
 {
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     wxStringTokenizer tokenizer(commands);
     if (!filename.EndsWith(wxT(".c"))) // force language reduces chance of error on STL headers
         tokenizer.SetString(commands + wxT(" -x c++"));
@@ -577,16 +614,23 @@ void ClangProxy::CreateTranslationUnit(const wxString& filename, const wxString&
         argsBuffer.push_back(compilerSwitch.ToUTF8());
         args.push_back(argsBuffer.back().data());
     }
-    m_TranslUnits.push_back(TranslationUnit(filename, args, m_ClIndex, &m_Database));
+    TranslationUnit TU(filename, args, m_ClIndex, &m_Database);
+    wxMutexLocker lock(m_Mutex);
+    m_TranslUnits.push_back(TU);
+    fprintf(stdout,"%s done.\n", __PRETTY_FUNCTION__);
 }
 
 int ClangProxy::GetTranslationUnitId(FileId fId)
 {
+    wxMutexLocker locker(m_Mutex);
     for (size_t i = 0; i < m_TranslUnits.size(); ++i)
     {
-        if (m_TranslUnits[i].Contains(fId))
+        if (m_TranslUnits[i].Contains(fId)){
+            //std::cout<<"TranslUnits index "<<i<<" has file id "<<fId<<std::endl;
             return i;
+        }
     }
+    //std::cout<<"file id "<<fId<<" not found in translUnits"<<std::endl;
     return wxNOT_FOUND;
 }
 
@@ -596,15 +640,16 @@ int ClangProxy::GetTranslationUnitId(const wxString& filename)
 }
 
 void ClangProxy::CodeCompleteAt(bool isAuto, const wxString& filename,
-                                int line, int column, int translId,
-                                const std::map<wxString, wxString>& unsavedFiles,
-                                std::vector<ClToken>& results)
+        int line, int column, int translId,
+        const std::map<wxString, wxString>& unsavedFiles,
+        std::vector<ClToken>& results)
 {
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     wxCharBuffer chName = filename.ToUTF8();
     std::vector<CXUnsavedFile> clUnsavedFiles;
     std::vector<wxCharBuffer> clFileBuffer;
     for (std::map<wxString, wxString>::const_iterator fileIt = unsavedFiles.begin();
-         fileIt != unsavedFiles.end(); ++fileIt)
+            fileIt != unsavedFiles.end(); ++fileIt)
     {
         CXUnsavedFile unit;
         clFileBuffer.push_back(fileIt->first.ToUTF8());
@@ -618,15 +663,21 @@ void ClangProxy::CodeCompleteAt(bool isAuto, const wxString& filename,
 #endif
         clUnsavedFiles.push_back(unit);
     }
-    CXCodeCompleteResults* clResults
-        = m_TranslUnits[translId].CodeCompleteAt(chName.data(), line, column,
-                                                 clUnsavedFiles.empty() ? nullptr : &clUnsavedFiles[0],
-                                                 clUnsavedFiles.size());
+    wxMutexLocker locker(m_Mutex);
+    CXCodeCompleteResults* clResults = m_TranslUnits[translId].CodeCompleteAt(chName.data(), line, column,
+                clUnsavedFiles.empty() ? nullptr : &clUnsavedFiles[0],
+                clUnsavedFiles.size());
     if (!clResults)
+    {
+        fprintf(stdout,"%s No results...\n", __PRETTY_FUNCTION__);
         return;
+    }
 
     if (isAuto && clang_codeCompleteGetContexts(clResults) == CXCompletionContext_Unknown)
+    {
+        fprintf(stdout,"%s unknown context\n", __PRETTY_FUNCTION__);
         return;
+    }
 
     const int numResults = clResults->NumResults;
     results.reserve(numResults);
@@ -682,18 +733,21 @@ void ClangProxy::CodeCompleteAt(bool isAuto, const wxString& filename,
                 }
                 CXString completeTxt = clang_getCompletionChunkText(token.CompletionString, chunkIdx);
                 results.push_back(ClToken(wxString::FromUTF8(clang_getCString(completeTxt)) + type,
-                                          resIdx, clang_getCompletionPriority(token.CompletionString),
-                                          ProxyHelper::GetTokenCategory(token.CursorKind)));
+                        resIdx, clang_getCompletionPriority(token.CompletionString),
+                        ProxyHelper::GetTokenCategory(token.CursorKind)));
                 clang_disposeString(completeTxt);
                 type.Empty();
                 break;
             }
         }
     }
+    fprintf(stdout,"%s done\n", __PRETTY_FUNCTION__);
+
 }
 
 wxString ClangProxy::DocumentCCToken(int translId, int tknId)
 {
+    wxMutexLocker  lock(m_Mutex);
     const CXCompletionResult* token = m_TranslUnits[translId].GetCCResult(tknId);
     if (!token)
         return wxEmptyString;
@@ -734,7 +788,7 @@ wxString ClangProxy::DocumentCCToken(int translId, int tknId)
         {
             const AbstractToken& aTkn = m_Database.GetToken(tId);
             CXCursor clTkn = m_TranslUnits[translId].GetTokensAt(m_Database.GetFilename(aTkn.fileId),
-                                                                 aTkn.line, aTkn.column);
+                    aTkn.line, aTkn.column);
             if (!clang_Cursor_isNull(clTkn) && !clang_isInvalid(clTkn.kind))
             {
                 CXComment docComment = clang_Cursor_getParsedComment(clTkn);
@@ -761,11 +815,12 @@ wxString ClangProxy::DocumentCCToken(int translId, int tknId)
     }
 
     return wxT("<html><body><br><tt>") + HTML_Writer::SyntaxHl(doc, m_CppKeywords)
-         + wxT("</tt>") + descriptor + wxT("</body></html>");
+            + wxT("</tt>") + descriptor + wxT("</body></html>");
 }
 
 wxString ClangProxy::GetCCInsertSuffix(int translId, int tknId, const wxString& newLine, std::pair<int, int>& offsets)
 {
+    wxMutexLocker lock(m_Mutex);
     const CXCompletionResult* token = m_TranslUnits[translId].GetCCResult(tknId);
     if (!token)
         return wxEmptyString;
@@ -779,39 +834,39 @@ wxString ClangProxy::GetCCInsertSuffix(int translId, int tknId, const wxString& 
     {
         switch (clang_getCompletionChunkKind(clCompStr, i))
         {
-            case CXCompletionChunk_TypedText:
-                if (state == init)
-                    state = store;
-                break;
+        case CXCompletionChunk_TypedText:
+            if (state == init)
+                state = store;
+            break;
 
-            case CXCompletionChunk_Placeholder:
-                if (state == store)
-                {
-                    CXString str = clang_getCompletionChunkText(clCompStr, i);
-                    const wxString& param = wxT("/*! ") + wxString::FromUTF8(clang_getCString(str)) + wxT(" !*/");
-                    offsets = std::make_pair(suffix.Length(), suffix.Length() + param.Length());
-                    suffix += param;
-                    clang_disposeString(str);
-                    state = exit;
-                }
-                break;
+        case CXCompletionChunk_Placeholder:
+            if (state == store)
+            {
+                CXString str = clang_getCompletionChunkText(clCompStr, i);
+                const wxString& param = wxT("/*! ") + wxString::FromUTF8(clang_getCString(str)) + wxT(" !*/");
+                offsets = std::make_pair(suffix.Length(), suffix.Length() + param.Length());
+                suffix += param;
+                clang_disposeString(str);
+                state = exit;
+            }
+            break;
 
-            case CXCompletionChunk_Informative:
-                break;
+        case CXCompletionChunk_Informative:
+            break;
 
-            case CXCompletionChunk_VerticalSpace:
-                if (state != init)
-                    suffix += newLine;
-                break;
+        case CXCompletionChunk_VerticalSpace:
+            if (state != init)
+                suffix += newLine;
+            break;
 
-            default:
-                if (state != init)
-                {
-                    CXString str = clang_getCompletionChunkText(clCompStr, i);
-                    suffix += wxString::FromUTF8(clang_getCString(str));
-                    clang_disposeString(str);
-                }
-                break;
+        default:
+            if (state != init)
+            {
+                CXString str = clang_getCompletionChunkText(clCompStr, i);
+                suffix += wxString::FromUTF8(clang_getCString(str));
+                clang_disposeString(str);
+            }
+            break;
         }
     }
     if (state != exit)
@@ -821,6 +876,7 @@ wxString ClangProxy::GetCCInsertSuffix(int translId, int tknId, const wxString& 
 
 void ClangProxy::RefineTokenType(int translId, int tknId, int& tknType)
 {
+    wxMutexLocker lock(m_Mutex);
     const CXCompletionResult* token = m_TranslUnits[translId].GetCCResult(tknId);
     if (!token)
         return;
@@ -833,7 +889,7 @@ void ClangProxy::RefineTokenType(int translId, int tknId, int& tknType)
         {
             const AbstractToken& aTkn = m_Database.GetToken(tId);
             CXCursor clTkn = m_TranslUnits[translId].GetTokensAt(m_Database.GetFilename(aTkn.fileId),
-                                                                 aTkn.line, aTkn.column);
+                    aTkn.line, aTkn.column);
             if (!clang_Cursor_isNull(clTkn) && !clang_isInvalid(clTkn.kind))
             {
                 TokenCategory tkCat
@@ -846,9 +902,10 @@ void ClangProxy::RefineTokenType(int translId, int tknId, int& tknType)
 }
 
 void ClangProxy::GetCallTipsAt(const wxString& filename, int line, int column,
-                               int translId, const wxString& tokenStr,
-                               std::vector<wxStringVec>& results)
+        int translId, const wxString& tokenStr,
+        std::vector<wxStringVec>& results)
 {
+    wxMutexLocker lock(m_Mutex);
     std::vector<CXCursor> tokenSet;
     if (column > static_cast<int>(tokenStr.Length()))
     {
@@ -875,7 +932,7 @@ void ClangProxy::GetCallTipsAt(const wxString& filename, int line, int column,
     {
         const AbstractToken& aTkn = m_Database.GetToken(*itr);
         CXCursor token = m_TranslUnits[translId].GetTokensAt(m_Database.GetFilename(aTkn.fileId),
-                                                             aTkn.line, aTkn.column);
+                aTkn.line, aTkn.column);
         if (!clang_Cursor_isNull(token) && !clang_isInvalid(token.kind))
             tokenSet.push_back(token);
     }
@@ -885,123 +942,124 @@ void ClangProxy::GetCallTipsAt(const wxString& filename, int line, int column,
         CXCursor token = tokenSet[tknIdx];
         switch (ProxyHelper::GetTokenCategory(token.kind, CX_CXXPublic))
         {
-            case tcVarPublic:
-            {
-                token = clang_getTypeDeclaration(clang_getCursorResultType(token));
-                if (!clang_Cursor_isNull(token) && !clang_isInvalid(token.kind))
-                    tokenSet.push_back(token);
-                break;
-            }
+        case tcVarPublic:
+        {
+            token = clang_getTypeDeclaration(clang_getCursorResultType(token));
+            if (!clang_Cursor_isNull(token) && !clang_isInvalid(token.kind))
+                tokenSet.push_back(token);
+            break;
+        }
 
-            case tcTypedefPublic:
-            {
-                token = clang_getTypeDeclaration(clang_getTypedefDeclUnderlyingType(token));
-                if (!clang_Cursor_isNull(token) && !clang_isInvalid(token.kind))
-                    tokenSet.push_back(token);
-                break;
-            }
+        case tcTypedefPublic:
+        {
+            token = clang_getTypeDeclaration(clang_getTypedefDeclUnderlyingType(token));
+            if (!clang_Cursor_isNull(token) && !clang_isInvalid(token.kind))
+                tokenSet.push_back(token);
+            break;
+        }
 
-            case tcClassPublic:
-            {
-                // search for constructors and 'operator()'
-                clang_visitChildren(token, &ProxyHelper::ClCallTipCtorAST_Visitor, &tokenSet);
-                break;
-            }
+        case tcClassPublic:
+        {
+            // search for constructors and 'operator()'
+            clang_visitChildren(token, &ProxyHelper::ClCallTipCtorAST_Visitor, &tokenSet);
+            break;
+        }
 
-            case tcCtorPublic:
+        case tcCtorPublic:
+        {
+            if (clang_getCXXAccessSpecifier(token) == CX_CXXPrivate)
+                break;
+            // fall through
+        }
+        case tcFuncPublic:
+        {
+            const CXCompletionString& clCompStr = clang_getCursorCompletionString(token);
+            wxStringVec entry;
+            int upperBound = clang_getNumCompletionChunks(clCompStr);
+            entry.push_back(wxEmptyString);
+            for (int chunkIdx = 0; chunkIdx < upperBound; ++chunkIdx)
             {
-                if (clang_getCXXAccessSpecifier(token) == CX_CXXPrivate)
-                    break;
-                // fall through
+                CXCompletionChunkKind kind = clang_getCompletionChunkKind(clCompStr, chunkIdx);
+                if (kind == CXCompletionChunk_TypedText)
+                {
+                    CXString str = clang_getCompletionParent(clCompStr, nullptr);
+                    wxString parent = wxString::FromUTF8(clang_getCString(str));
+                    if (!parent.IsEmpty())
+                        entry[0] += parent + wxT("::");
+                    clang_disposeString(str);
+                }
+                else if (kind == CXCompletionChunk_LeftParen)
+                {
+                    if (entry[0].IsEmpty() || !entry[0].EndsWith(wxT("operator")))
+                        break;
+                }
+                CXString str = clang_getCompletionChunkText(clCompStr, chunkIdx);
+                entry[0] += wxString::FromUTF8(clang_getCString(str));
+                if (kind == CXCompletionChunk_ResultType)
+                {
+                    if (entry[0].Length() > 2 && entry[0][entry[0].Length() - 2] == wxT(' '))
+                        entry[0].RemoveLast(2) += entry[0].Last();
+                    entry[0] += wxT(' ');
+                }
+                clang_disposeString(str);
             }
-            case tcFuncPublic:
+            entry[0] += wxT('(');
+            int numArgs = clang_Cursor_getNumArguments(token);
+            for (int argIdx = 0; argIdx < numArgs; ++argIdx)
             {
-                const CXCompletionString& clCompStr = clang_getCursorCompletionString(token);
-                wxStringVec entry;
-                int upperBound = clang_getNumCompletionChunks(clCompStr);
-                entry.push_back(wxEmptyString);
+                CXCursor arg = clang_Cursor_getArgument(token, argIdx);
+
+                wxString tknStr;
+                const CXCompletionString& argStr = clang_getCursorCompletionString(arg);
+                upperBound = clang_getNumCompletionChunks(argStr);
                 for (int chunkIdx = 0; chunkIdx < upperBound; ++chunkIdx)
                 {
-                    CXCompletionChunkKind kind = clang_getCompletionChunkKind(clCompStr, chunkIdx);
+                    CXCompletionChunkKind kind = clang_getCompletionChunkKind(argStr, chunkIdx);
                     if (kind == CXCompletionChunk_TypedText)
                     {
-                        CXString str = clang_getCompletionParent(clCompStr, nullptr);
+                        CXString str = clang_getCompletionParent(argStr, nullptr);
                         wxString parent = wxString::FromUTF8(clang_getCString(str));
                         if (!parent.IsEmpty())
-                            entry[0] += parent + wxT("::");
+                            tknStr += parent + wxT("::");
                         clang_disposeString(str);
                     }
-                    else if (kind == CXCompletionChunk_LeftParen)
-                    {
-                        if (entry[0].IsEmpty() || !entry[0].EndsWith(wxT("operator")))
-                            break;
-                    }
-                    CXString str = clang_getCompletionChunkText(clCompStr, chunkIdx);
-                    entry[0] += wxString::FromUTF8(clang_getCString(str));
+                    CXString str = clang_getCompletionChunkText(argStr, chunkIdx);
+                    tknStr += wxString::FromUTF8(clang_getCString(str));
                     if (kind == CXCompletionChunk_ResultType)
                     {
-                        if (entry[0].Length() > 2 && entry[0][entry[0].Length() - 2] == wxT(' '))
-                            entry[0].RemoveLast(2) += entry[0].Last();
-                        entry[0] += wxT(' ');
+                        if (tknStr.Length() > 2 && tknStr[tknStr.Length() - 2] == wxT(' '))
+                            tknStr.RemoveLast(2) += tknStr.Last();
+                        tknStr += wxT(' ');
                     }
                     clang_disposeString(str);
                 }
-                entry[0] += wxT('(');
-                int numArgs = clang_Cursor_getNumArguments(token);
-                for (int argIdx = 0; argIdx < numArgs; ++argIdx)
-                {
-                    CXCursor arg = clang_Cursor_getArgument(token, argIdx);
 
-                    wxString tknStr;
-                    const CXCompletionString& argStr = clang_getCursorCompletionString(arg);
-                    upperBound = clang_getNumCompletionChunks(argStr);
-                    for (int chunkIdx = 0; chunkIdx < upperBound; ++chunkIdx)
-                    {
-                        CXCompletionChunkKind kind = clang_getCompletionChunkKind(argStr, chunkIdx);
-                        if (kind == CXCompletionChunk_TypedText)
-                        {
-                            CXString str = clang_getCompletionParent(argStr, nullptr);
-                            wxString parent = wxString::FromUTF8(clang_getCString(str));
-                            if (!parent.IsEmpty())
-                                tknStr += parent + wxT("::");
-                            clang_disposeString(str);
-                        }
-                        CXString str = clang_getCompletionChunkText(argStr, chunkIdx);
-                        tknStr += wxString::FromUTF8(clang_getCString(str));
-                        if (kind == CXCompletionChunk_ResultType)
-                        {
-                            if (tknStr.Length() > 2 && tknStr[tknStr.Length() - 2] == wxT(' '))
-                                tknStr.RemoveLast(2) += tknStr.Last();
-                            tknStr += wxT(' ');
-                        }
-                        clang_disposeString(str);
-                    }
-
-                    entry.push_back(tknStr.Trim());
-                }
-                entry.push_back(wxT(')'));
-                wxString composit;
-                for (wxStringVec::const_iterator itr = entry.begin();
-                     itr != entry.end(); ++itr)
-                {
-                    composit += *itr;
-                }
-                if (uniqueTips.find(composit) != uniqueTips.end())
-                    break;
-                uniqueTips.insert(composit);
-                results.push_back(entry);
-                break;
+                entry.push_back(tknStr.Trim());
             }
-
-            default:
+            entry.push_back(wxT(')'));
+            wxString composit;
+            for (wxStringVec::const_iterator itr = entry.begin();
+                    itr != entry.end(); ++itr)
+            {
+                composit += *itr;
+            }
+            if (uniqueTips.find(composit) != uniqueTips.end())
                 break;
+            uniqueTips.insert(composit);
+            results.push_back(entry);
+            break;
+        }
+
+        default:
+            break;
         }
     }
 }
 
 void ClangProxy::GetTokensAt(const wxString& filename, int line, int column,
-                             int translId, wxStringVec& results)
+        int translId, wxStringVec& results)
 {
+    wxMutexLocker lock(m_Mutex);
     CXCursor token = m_TranslUnits[translId].GetTokensAt(filename, line, column);
     if (clang_Cursor_isNull(token))
         return;
@@ -1035,69 +1093,74 @@ void ClangProxy::GetTokensAt(const wxString& filename, int line, int column,
     {
         switch (token.kind)
         {
-            case CXCursor_StructDecl:
-            case CXCursor_ClassDecl:
-            case CXCursor_ClassTemplate:
-            case CXCursor_ClassTemplatePartialSpecialization:
+        case CXCursor_StructDecl:
+        case CXCursor_ClassDecl:
+        case CXCursor_ClassTemplate:
+        case CXCursor_ClassTemplatePartialSpecialization:
+        {
+            if (token.kind == CXCursor_StructDecl)
+                tknStr.Prepend(wxT("struct "));
+            else
+                tknStr.Prepend(wxT("class "));
+            wxStringVec directAncestors;
+            clang_visitChildren(token, &ProxyHelper::ClInheritance_Visitor, &directAncestors);
+            for (wxStringVec::const_iterator daItr = directAncestors.begin();
+                    daItr != directAncestors.end(); ++daItr)
             {
-                if (token.kind == CXCursor_StructDecl)
-                    tknStr.Prepend(wxT("struct "));
+                if (daItr == directAncestors.begin())
+                    tknStr += wxT(" : ");
                 else
-                    tknStr.Prepend(wxT("class "));
-                wxStringVec directAncestors;
-                clang_visitChildren(token, &ProxyHelper::ClInheritance_Visitor, &directAncestors);
-                for (wxStringVec::const_iterator daItr = directAncestors.begin();
-                     daItr != directAncestors.end(); ++daItr)
-                {
-                    if (daItr == directAncestors.begin())
-                        tknStr += wxT(" : ");
-                    else
-                        tknStr += wxT(", ");
-                    tknStr += *daItr;
-                }
-                break;
+                    tknStr += wxT(", ");
+                tknStr += *daItr;
             }
+            break;
+        }
 
-            case CXCursor_UnionDecl:
-                tknStr.Prepend(wxT("union "));
-                break;
+        case CXCursor_UnionDecl:
+            tknStr.Prepend(wxT("union "));
+            break;
 
-            case CXCursor_EnumDecl:
-                tknStr.Prepend(wxT("enum "));
-                break;
+        case CXCursor_EnumDecl:
+            tknStr.Prepend(wxT("enum "));
+            break;
 
-            case CXCursor_EnumConstantDecl:
-                tknStr += wxT("=") + ProxyHelper::GetEnumValStr(token);
-                break;
+        case CXCursor_EnumConstantDecl:
+            tknStr += wxT("=") + ProxyHelper::GetEnumValStr(token);
+            break;
 
-            case CXCursor_TypedefDecl:
-            {
-                CXString str = clang_getTypeSpelling(clang_getTypedefDeclUnderlyingType(token));
-                wxString type = wxString::FromUTF8(clang_getCString(str));
-                clang_disposeString(str);
-                if (!type.IsEmpty())
-                    tknStr.Prepend(wxT("typedef ") + type + wxT(" "));
-                break;
-            }
+        case CXCursor_TypedefDecl:
+        {
+            CXString str = clang_getTypeSpelling(clang_getTypedefDeclUnderlyingType(token));
+            wxString type = wxString::FromUTF8(clang_getCString(str));
+            clang_disposeString(str);
+            if (!type.IsEmpty())
+                tknStr.Prepend(wxT("typedef ") + type + wxT(" "));
+            break;
+        }
 
-            case CXCursor_Namespace:
-                tknStr.Prepend(wxT("namespace "));
-                break;
+        case CXCursor_Namespace:
+            tknStr.Prepend(wxT("namespace "));
+            break;
 
-            case CXCursor_MacroDefinition:
-                tknStr.Prepend(wxT("#define ")); // TODO: show (partial) definition
-                break;
+        case CXCursor_MacroDefinition:
+            tknStr.Prepend(wxT("#define ")); // TODO: show (partial) definition
+            break;
 
-            default:
-                break;
+        default:
+            break;
         }
         results.push_back(tknStr);
     }
 }
 
+/**
+ * Get all occurences of the token under the supplied cursor.
+ */
+
 void ClangProxy::GetOccurrencesOf(const wxString& filename, int line, int column,
-                                  int translId, std::vector< std::pair<int, int> >& results)
+        int translId, std::vector< std::pair<int, int> >& results)
 {
+    wxMutexLocker lock(m_Mutex);
     CXCursor token = m_TranslUnits[translId].GetTokensAt(filename, line, column);
     if (clang_Cursor_isNull(token))
         return;
@@ -1106,8 +1169,9 @@ void ClangProxy::GetOccurrencesOf(const wxString& filename, int line, int column
     clang_findReferencesInFile(token, m_TranslUnits[translId].GetFileHandle(filename), visitor);
 }
 
-void ClangProxy::ResolveTokenAt(wxString& filename, int& line, int& column, int translId)
+void ClangProxy::ResolveDeclTokenAt(wxString& filename, int& line, int& column, int translId)
 {
+    wxMutexLocker lock(m_Mutex);
     CXCursor token = m_TranslUnits[translId].GetTokensAt(filename, line, column);
     if (clang_Cursor_isNull(token))
         return;
@@ -1137,7 +1201,7 @@ void ClangProxy::Reparse(int translId, const std::map<wxString, wxString>& unsav
     std::vector<CXUnsavedFile> clUnsavedFiles;
     std::vector<wxCharBuffer> clFileBuffer;
     for (std::map<wxString, wxString>::const_iterator fileIt = unsavedFiles.begin();
-         fileIt != unsavedFiles.end(); ++fileIt)
+            fileIt != unsavedFiles.end(); ++fileIt)
     {
         CXUnsavedFile unit;
         clFileBuffer.push_back(fileIt->first.ToUTF8());
@@ -1151,10 +1215,64 @@ void ClangProxy::Reparse(int translId, const std::map<wxString, wxString>& unsav
 #endif
         clUnsavedFiles.push_back(unit);
     }
+
+    wxMutexLocker lock(m_Mutex);
     m_TranslUnits[translId].Reparse(clUnsavedFiles.size(), clUnsavedFiles.empty() ? nullptr : &clUnsavedFiles[0]);
 }
 
 void ClangProxy::GetDiagnostics(int translId, std::vector<ClDiagnostic>& diagnostics)
 {
+    wxMutexLocker lock(m_Mutex);
     m_TranslUnits[translId].GetDiagnostics(diagnostics);
 }
+
+void ClangProxy::AddPendingTask( ClangProxy::Task& task )
+{
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+    ClangProxy::Task* pTask = task.Clone();
+    wxMutexLocker locker(m_TaskQueueMutex);
+    m_TaskQueue.push(pTask);
+    m_ConditionQueueNotEmpty.Signal();
+    fprintf(stdout,"%s done\n", __PRETTY_FUNCTION__);
+}
+
+wxThread::ExitCode ClangProxy::TaskThread::Entry()
+{
+    while(m_pClangProxy->m_pThread != NULL)
+    {
+        Task* pTask = NULL;
+        {
+            wxMutexLocker lock(m_pClangProxy->m_TaskQueueMutex);
+            while(m_pClangProxy->m_TaskQueue.empty()){
+                wxCondError err = m_pClangProxy->m_ConditionQueueNotEmpty.Wait();
+                if( err != wxCOND_NO_ERROR )
+                {
+                    m_pClangProxy->m_pThread = NULL;
+                    return (wxThread::ExitCode)-1;
+                }
+            }
+            pTask = m_pClangProxy->m_TaskQueue.front();
+            m_pClangProxy->m_TaskQueue.pop();
+        }
+        if( pTask )
+        {
+            try{
+                (*pTask)(*m_pClangProxy);
+            }catch(...)
+            {
+                fprintf(stdout,"%s: Exception caught\n", __PRETTY_FUNCTION__);
+                continue;
+            }
+            pTask->Completed();
+            if( m_pClangProxy->m_pEventCallbackHandler ){
+                if( pTask->GetCallbackEventType() != 0 )
+                {
+                    ClangProxy::CallbackEvent evt( pTask->GetCallbackEventType(), pTask->GetCallbackEventId(), pTask);
+                    m_pClangProxy->m_pEventCallbackHandler->AddPendingEvent( evt );
+                }
+            }
+        }
+    }
+    return (wxThread::ExitCode)0;
+}
+

--- a/clangproxy.cpp
+++ b/clangproxy.cpp
@@ -17,559 +17,559 @@
 
 namespace ProxyHelper
 {
-static TokenCategory GetTokenCategory(CXCursorKind kind, CX_CXXAccessSpecifier access = CX_CXXInvalidAccessSpecifier)
-{
-    switch (kind)
+    static TokenCategory GetTokenCategory(CXCursorKind kind, CX_CXXAccessSpecifier access = CX_CXXInvalidAccessSpecifier)
     {
-    case CXCursor_StructDecl:
-    case CXCursor_UnionDecl:
-    case CXCursor_ClassDecl:
-    case CXCursor_ClassTemplate:
-        switch (access)
+        switch (kind)
         {
-        case CX_CXXPublic:
-            return tcClassPublic;
-        case CX_CXXProtected:
-            return tcClassProtected;
-        case CX_CXXPrivate:
-            return tcClassPrivate;
+        case CXCursor_StructDecl:
+        case CXCursor_UnionDecl:
+        case CXCursor_ClassDecl:
+        case CXCursor_ClassTemplate:
+            switch (access)
+            {
+            case CX_CXXPublic:
+                return tcClassPublic;
+            case CX_CXXProtected:
+                return tcClassProtected;
+            case CX_CXXPrivate:
+                return tcClassPrivate;
+            default:
+            case CX_CXXInvalidAccessSpecifier:
+                return tcClass;
+            }
+
+        case CXCursor_Constructor:
+            switch (access)
+            {
+            default:
+            case CX_CXXInvalidAccessSpecifier:
+            case CX_CXXPublic:
+                return tcCtorPublic;
+            case CX_CXXProtected:
+                return tcCtorProtected;
+            case CX_CXXPrivate:
+                return tcCtorPrivate;
+            }
+
+        case CXCursor_Destructor:
+            switch (access)
+            {
+            default:
+            case CX_CXXInvalidAccessSpecifier:
+            case CX_CXXPublic:
+                return tcDtorPublic;
+            case CX_CXXProtected:
+                return tcDtorProtected;
+            case CX_CXXPrivate:
+                return tcDtorPrivate;
+            }
+
+        case CXCursor_FunctionDecl:
+        case CXCursor_CXXMethod:
+        case CXCursor_FunctionTemplate:
+            switch (access)
+            {
+            default:
+            case CX_CXXInvalidAccessSpecifier:
+            case CX_CXXPublic:
+                return tcFuncPublic;
+            case CX_CXXProtected:
+                return tcFuncProtected;
+            case CX_CXXPrivate:
+                return tcFuncPrivate;
+            }
+
+        case CXCursor_FieldDecl:
+        case CXCursor_VarDecl:
+        case CXCursor_ParmDecl:
+            switch (access)
+            {
+            default:
+            case CX_CXXInvalidAccessSpecifier:
+            case CX_CXXPublic:
+                return tcVarPublic;
+            case CX_CXXProtected:
+                return tcVarProtected;
+            case CX_CXXPrivate:
+                return tcVarPrivate;
+            }
+
+        case CXCursor_MacroDefinition:
+            return tcMacroDef;
+
+        case CXCursor_EnumDecl:
+            switch (access)
+            {
+            case CX_CXXPublic:
+                return tcEnumPublic;
+            case CX_CXXProtected:
+                return tcEnumProtected;
+            case CX_CXXPrivate:
+                return tcEnumPrivate;
+            default:
+            case CX_CXXInvalidAccessSpecifier:
+                return tcEnum;
+            }
+
+        case CXCursor_EnumConstantDecl:
+            return tcEnumerator;
+
+        case CXCursor_Namespace:
+            return tcNamespace;
+
+        case CXCursor_TypedefDecl:
+            switch (access)
+            {
+            case CX_CXXPublic:
+                return tcTypedefPublic;
+            case CX_CXXProtected:
+                return tcTypedefProtected;
+            case CX_CXXPrivate:
+                return tcTypedefPrivate;
+            default:
+            case CX_CXXInvalidAccessSpecifier:
+                return tcTypedef;
+            }
+
         default:
-        case CX_CXXInvalidAccessSpecifier:
-            return tcClass;
+            return tcNone;
         }
-
-    case CXCursor_Constructor:
-        switch (access)
-        {
-        default:
-        case CX_CXXInvalidAccessSpecifier:
-        case CX_CXXPublic:
-            return tcCtorPublic;
-        case CX_CXXProtected:
-            return tcCtorProtected;
-        case CX_CXXPrivate:
-            return tcCtorPrivate;
-        }
-
-    case CXCursor_Destructor:
-        switch (access)
-        {
-        default:
-        case CX_CXXInvalidAccessSpecifier:
-        case CX_CXXPublic:
-            return tcDtorPublic;
-        case CX_CXXProtected:
-            return tcDtorProtected;
-        case CX_CXXPrivate:
-            return tcDtorPrivate;
-        }
-
-    case CXCursor_FunctionDecl:
-    case CXCursor_CXXMethod:
-    case CXCursor_FunctionTemplate:
-        switch (access)
-        {
-        default:
-        case CX_CXXInvalidAccessSpecifier:
-        case CX_CXXPublic:
-            return tcFuncPublic;
-        case CX_CXXProtected:
-            return tcFuncProtected;
-        case CX_CXXPrivate:
-            return tcFuncPrivate;
-        }
-
-    case CXCursor_FieldDecl:
-    case CXCursor_VarDecl:
-    case CXCursor_ParmDecl:
-        switch (access)
-        {
-        default:
-        case CX_CXXInvalidAccessSpecifier:
-        case CX_CXXPublic:
-            return tcVarPublic;
-        case CX_CXXProtected:
-            return tcVarProtected;
-        case CX_CXXPrivate:
-            return tcVarPrivate;
-        }
-
-    case CXCursor_MacroDefinition:
-        return tcMacroDef;
-
-    case CXCursor_EnumDecl:
-        switch (access)
-        {
-        case CX_CXXPublic:
-            return tcEnumPublic;
-        case CX_CXXProtected:
-            return tcEnumProtected;
-        case CX_CXXPrivate:
-            return tcEnumPrivate;
-        default:
-        case CX_CXXInvalidAccessSpecifier:
-            return tcEnum;
-        }
-
-    case CXCursor_EnumConstantDecl:
-        return tcEnumerator;
-
-    case CXCursor_Namespace:
-        return tcNamespace;
-
-    case CXCursor_TypedefDecl:
-        switch (access)
-        {
-        case CX_CXXPublic:
-            return tcTypedefPublic;
-        case CX_CXXProtected:
-            return tcTypedefProtected;
-        case CX_CXXPrivate:
-            return tcTypedefPrivate;
-        default:
-        case CX_CXXInvalidAccessSpecifier:
-            return tcTypedef;
-        }
-
-    default:
-        return tcNone;
-    }
-}
-
-static CXChildVisitResult ClCallTipCtorAST_Visitor(CXCursor cursor,
-        CXCursor WXUNUSED(parent),
-        CXClientData client_data)
-{
-    switch (cursor.kind)
-    {
-    case CXCursor_Constructor:
-    {
-        std::vector<CXCursor>* tokenSet
-            = static_cast<std::vector<CXCursor>*>(client_data);
-        tokenSet->push_back(cursor);
-        break;
     }
 
-    case CXCursor_FunctionDecl:
-    case CXCursor_CXXMethod:
-    case CXCursor_FunctionTemplate:
+    static CXChildVisitResult ClCallTipCtorAST_Visitor(CXCursor cursor,
+            CXCursor WXUNUSED(parent),
+            CXClientData client_data)
     {
-        CXString str = clang_getCursorSpelling(cursor);
-        if (strcmp(clang_getCString(str), "operator()") == 0)
+        switch (cursor.kind)
+        {
+        case CXCursor_Constructor:
         {
             std::vector<CXCursor>* tokenSet
                 = static_cast<std::vector<CXCursor>*>(client_data);
             tokenSet->push_back(cursor);
+            break;
         }
+
+        case CXCursor_FunctionDecl:
+        case CXCursor_CXXMethod:
+        case CXCursor_FunctionTemplate:
+        {
+            CXString str = clang_getCursorSpelling(cursor);
+            if (strcmp(clang_getCString(str), "operator()") == 0)
+            {
+                std::vector<CXCursor>* tokenSet
+                    = static_cast<std::vector<CXCursor>*>(client_data);
+                tokenSet->push_back(cursor);
+            }
+            clang_disposeString(str);
+            break;
+        }
+
+        default:
+            break;
+        }
+        return CXChildVisit_Continue;
+    }
+
+    static CXChildVisitResult ClInheritance_Visitor(CXCursor cursor,
+            CXCursor WXUNUSED(parent),
+            CXClientData client_data)
+    {
+        if (cursor.kind != CXCursor_CXXBaseSpecifier)
+            return CXChildVisit_Break;
+        CXString str = clang_getTypeSpelling(clang_getCursorType(cursor));
+        static_cast<wxStringVec*>(client_data)->push_back(wxString::FromUTF8(clang_getCString(str)));
         clang_disposeString(str);
-        break;
+        return CXChildVisit_Continue;
     }
 
-    default:
-        break;
-    }
-    return CXChildVisit_Continue;
-}
-
-static CXChildVisitResult ClInheritance_Visitor(CXCursor cursor,
-        CXCursor WXUNUSED(parent),
-        CXClientData client_data)
-{
-    if (cursor.kind != CXCursor_CXXBaseSpecifier)
-        return CXChildVisit_Break;
-    CXString str = clang_getTypeSpelling(clang_getCursorType(cursor));
-    static_cast<wxStringVec*>(client_data)->push_back(wxString::FromUTF8(clang_getCString(str)));
-    clang_disposeString(str);
-    return CXChildVisit_Continue;
-}
-
-static CXChildVisitResult ClEnum_Visitor(CXCursor cursor,
-        CXCursor WXUNUSED(parent),
-        CXClientData client_data)
-{
-    if (cursor.kind != CXCursor_EnumConstantDecl)
-        return CXChildVisit_Break;
-    int* counts = static_cast<int*>(client_data);
-    long long val = clang_getEnumConstantDeclValue(cursor);
-    if (val > 0 && !((val - 1) & val)) // is power of 2
-        ++counts[0];
-    ++counts[1];
-    counts[2] = std::max(counts[2], static_cast<int>(val));
-    return CXChildVisit_Continue;
-}
-
-static void ResolveCursorDecl(CXCursor& token)
-{
-    CXCursor resolve = clang_getCursorDefinition(token);
-    if (clang_Cursor_isNull(resolve) || clang_isInvalid(token.kind))
+    static CXChildVisitResult ClEnum_Visitor(CXCursor cursor,
+            CXCursor WXUNUSED(parent),
+            CXClientData client_data)
     {
-        resolve = clang_getCursorReferenced(token);
-        if (!clang_Cursor_isNull(resolve) && !clang_isInvalid(token.kind))
+        if (cursor.kind != CXCursor_EnumConstantDecl)
+            return CXChildVisit_Break;
+        int* counts = static_cast<int*>(client_data);
+        long long val = clang_getEnumConstantDeclValue(cursor);
+        if (val > 0 && !((val - 1) & val)) // is power of 2
+            ++counts[0];
+        ++counts[1];
+        counts[2] = std::max(counts[2], static_cast<int>(val));
+        return CXChildVisit_Continue;
+    }
+
+    static void ResolveCursorDecl(CXCursor& token)
+    {
+        CXCursor resolve = clang_getCursorDefinition(token);
+        if (clang_Cursor_isNull(resolve) || clang_isInvalid(token.kind))
+        {
+            resolve = clang_getCursorReferenced(token);
+            if (!clang_Cursor_isNull(resolve) && !clang_isInvalid(token.kind))
+                token = resolve;
+        }
+        else
             token = resolve;
     }
-    else
-        token = resolve;
-}
 
-static void ResolveCursorImpl(CXCursor& token)
-{
-    CXCursor resolve = clang_getCursorReferenced(token);
-    if (clang_Cursor_isNull(resolve) || clang_isInvalid(token.kind))
+    static void ResolveCursorImpl(CXCursor& token)
     {
-        resolve = clang_getCursorDefinition(token);
-        if (!clang_Cursor_isNull(resolve) && !clang_isInvalid(token.kind))
+        CXCursor resolve = clang_getCursorReferenced(token);
+        if (clang_Cursor_isNull(resolve) || clang_isInvalid(token.kind))
+        {
+            resolve = clang_getCursorDefinition(token);
+            if (!clang_Cursor_isNull(resolve) && !clang_isInvalid(token.kind))
+                token = resolve;
+        }
+        else
             token = resolve;
     }
-    else
-        token = resolve;
-}
 
-static CXVisitorResult ReferencesVisitor(CXClientData context,
-        CXCursor WXUNUSED(cursor),
-        CXSourceRange range)
-{
-    unsigned rgStart, rgEnd;
-    CXSourceLocation rgLoc = clang_getRangeStart(range);
-    clang_getSpellingLocation(rgLoc, nullptr, nullptr, nullptr, &rgStart);
-    rgLoc = clang_getRangeEnd(range);
-    clang_getSpellingLocation(rgLoc, nullptr, nullptr, nullptr, &rgEnd);
-    if (rgStart != rgEnd)
+    static CXVisitorResult ReferencesVisitor(CXClientData context,
+            CXCursor WXUNUSED(cursor),
+            CXSourceRange range)
     {
-        static_cast<std::vector< std::pair<int, int> >*>(context)
-        ->push_back(std::make_pair<int, int>(rgStart, rgEnd - rgStart));
+        unsigned rgStart, rgEnd;
+        CXSourceLocation rgLoc = clang_getRangeStart(range);
+        clang_getSpellingLocation(rgLoc, nullptr, nullptr, nullptr, &rgStart);
+        rgLoc = clang_getRangeEnd(range);
+        clang_getSpellingLocation(rgLoc, nullptr, nullptr, nullptr, &rgEnd);
+        if (rgStart != rgEnd)
+        {
+            static_cast<std::vector< std::pair<int, int> >*>(context)
+            ->push_back(std::make_pair<int, int>(rgStart, rgEnd - rgStart));
+        }
+        return CXVisit_Continue;
     }
-    return CXVisit_Continue;
-}
 
-static wxString GetEnumValStr(CXCursor token)
-{
-    int counts[] = {0, 0, 0}; // (numPowerOf2, numTotal, maxVal)
-    clang_visitChildren(clang_getCursorSemanticParent(token), &ProxyHelper::ClEnum_Visitor, counts);
-    wxLongLong val(clang_getEnumConstantDeclValue(token));
-    if ((   (counts[0] == counts[1])
-            || (counts[1] > 5 && counts[0] * 2 >= counts[1]) ) && val >= 0)
+    static wxString GetEnumValStr(CXCursor token)
     {
-        // lots of 2^n enum constants, probably bitmask -> display in hexadecimal
-        wxString formatStr
-            = wxString::Format(wxT("0x%%0%ulX"),
-                    wxString::Format(wxT("%X"), // count max width for 0-padding
-                            static_cast<unsigned>(counts[2])).Length());
-        return wxString::Format(formatStr, static_cast<unsigned long>(val.GetValue()));
+        int counts[] = {0, 0, 0}; // (numPowerOf2, numTotal, maxVal)
+        clang_visitChildren(clang_getCursorSemanticParent(token), &ProxyHelper::ClEnum_Visitor, counts);
+        wxLongLong val(clang_getEnumConstantDeclValue(token));
+        if ((   (counts[0] == counts[1])
+                || (counts[1] > 5 && counts[0] * 2 >= counts[1]) ) && val >= 0)
+        {
+            // lots of 2^n enum constants, probably bitmask -> display in hexadecimal
+            wxString formatStr
+                = wxString::Format(wxT("0x%%0%ulX"),
+                        wxString::Format(wxT("%X"), // count max width for 0-padding
+                                static_cast<unsigned>(counts[2])).Length());
+            return wxString::Format(formatStr, static_cast<unsigned long>(val.GetValue()));
+        }
+        else
+            return val.ToString();
     }
-    else
-        return val.ToString();
-}
 }
 
 namespace HTML_Writer
 {
-static wxString Escape(const wxString& text)
-{
-    wxString html;
-    html.reserve(text.size());
-    for (wxString::const_iterator itr = text.begin();
-            itr != text.end(); ++itr)
+    static wxString Escape(const wxString& text)
     {
-        switch (*itr)
+        wxString html;
+        html.reserve(text.size());
+        for (wxString::const_iterator itr = text.begin();
+                itr != text.end(); ++itr)
         {
-        case wxT('&'):
-            html += wxT("&amp;");
-            break;
-        case wxT('\"'):
-            html += wxT("&quot;");
-            break;
-        case wxT('\''):
-            html += wxT("&apos;");
-            break;
-        case wxT('<'):
-            html += wxT("&lt;");
-            break;
-        case wxT('>'):
-            html += wxT("&gt;");
-            break;
-        case wxT('\n'):
-            html += wxT("<br>");
-            break;
-        default:
-            html += *itr;
-            break;
+            switch (*itr)
+            {
+            case wxT('&'):
+                html += wxT("&amp;");
+                break;
+            case wxT('\"'):
+                html += wxT("&quot;");
+                break;
+            case wxT('\''):
+                html += wxT("&apos;");
+                break;
+            case wxT('<'):
+                html += wxT("&lt;");
+                break;
+            case wxT('>'):
+                html += wxT("&gt;");
+                break;
+            case wxT('\n'):
+                html += wxT("<br>");
+                break;
+            default:
+                html += *itr;
+                break;
+            }
         }
+        return html;
     }
-    return html;
-}
 
-static wxString Colourise(const wxString& text, const wxString& colour)
-{
-    return wxT("<font color=\"") + colour + wxT("\">") + text + wxT("</font>");
-}
-
-static wxString SyntaxHl(const wxString& code, const std::vector<wxString>& cppKeywords) // C++ style (ish)
-{
-    wxString html;
-    html.reserve(code.size());
-    int stRg = 0;
-    int style = wxSCI_C_DEFAULT;
-    const int codeLen = code.Length();
-    for (int enRg = 0; enRg <= codeLen; ++enRg)
+    static wxString Colourise(const wxString& text, const wxString& colour)
     {
-        wxChar ch = (enRg < codeLen ? code[enRg] : wxT('\0'));
-        wxChar nextCh = (enRg < codeLen - 1 ? code[enRg + 1] : wxT('\0'));
-        switch (style)
-        {
-        default:
-        case wxSCI_C_DEFAULT:
-        {
-            if (wxIsalpha(ch) || ch == wxT('_'))
-                style = wxSCI_C_IDENTIFIER;
-            else if (wxIsdigit(ch))
-                style = wxSCI_C_NUMBER;
-            else if (ch == wxT('"'))
-                style = wxSCI_C_STRING;
-            else if (ch == wxT('\''))
-                style = wxSCI_C_CHARACTER;
-            else if (ch == wxT('/') && nextCh == wxT('/'))
-                style = wxSCI_C_COMMENTLINE;
-            else if (wxIspunct(ch))
-                style = wxSCI_C_OPERATOR;
-            else
-                break;
-            if (stRg != enRg)
-            {
-                html += Escape(code.Mid(stRg, enRg - stRg));
-                stRg = enRg;
-            }
-            break;
-        }
-
-        case wxSCI_C_IDENTIFIER:
-        {
-            if (wxIsalnum(ch) || ch == wxT('_'))
-                break;
-            if (stRg != enRg)
-            {
-                const wxString& tkn = code.Mid(stRg, enRg - stRg);
-                if (std::binary_search(cppKeywords.begin(), cppKeywords.end(), tkn))
-                    html += wxT("<b>") + Colourise(Escape(tkn), wxT("#00008b")) + wxT("</b>"); // DarkBlue
-                else
-                    html += Escape(tkn);
-                stRg = enRg;
-                --enRg;
-            }
-            style = wxSCI_C_DEFAULT;
-            break;
-        }
-
-        case wxSCI_C_NUMBER:
-        {
-            if (wxIsalnum(ch))
-                break;
-            if (stRg != enRg)
-            {
-                html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("Magenta"));
-                stRg = enRg;
-                --enRg;
-            }
-            style = wxSCI_C_DEFAULT;
-            break;
-        }
-
-        case wxSCI_C_STRING:
-        {
-            if (ch == wxT('\\'))
-            {
-                if (nextCh != wxT('\n'))
-                    ++enRg;
-                break;
-            }
-            else if (ch && ch != wxT('"') && ch != wxT('\n'))
-                break;
-            if (stRg != enRg)
-            {
-                if (ch == wxT('"'))
-                    ++enRg;
-                html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("#0000cd")); // MediumBlue
-                stRg = enRg;
-                --enRg;
-            }
-            style = wxSCI_C_DEFAULT;
-            break;
-        }
-
-        case wxSCI_C_CHARACTER:
-        {
-            if (ch == wxT('\\'))
-            {
-                if (nextCh != wxT('\n'))
-                    ++enRg;
-                break;
-            }
-            else if (ch && ch != wxT('\'') && ch != wxT('\n'))
-                break;
-            if (stRg != enRg)
-            {
-                if (ch == wxT('\''))
-                    ++enRg;
-                html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("GoldenRod"));
-                stRg = enRg;
-                --enRg;
-            }
-            style = wxSCI_C_DEFAULT;
-            break;
-        }
-
-        case wxSCI_C_COMMENTLINE:
-        {
-            if (ch && ch != wxT('\n'))
-                break;
-            if (stRg != enRg)
-            {
-                html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("#778899")); // LightSlateGray
-                stRg = enRg;
-            }
-            style = wxSCI_C_DEFAULT;
-            break;
-        }
-
-        case wxSCI_C_OPERATOR:
-        {
-            if (wxIspunct(ch) && ch != wxT('"') && ch != wxT('\'') && ch != wxT('_'))
-                break;
-            if (stRg != enRg)
-            {
-                html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("Red"));
-                stRg = enRg;
-                --enRg;
-            }
-            style = wxSCI_C_DEFAULT;
-            break;
-        }
-        }
+        return wxT("<font color=\"") + colour + wxT("\">") + text + wxT("</font>");
     }
-    return html;
-}
 
-static void FormatDocumentation(CXComment comment, wxString& doc, const std::vector<wxString>& cppKeywords)
-{
-    size_t numChildren = clang_Comment_getNumChildren(comment);
-    for (size_t childIdx = 0; childIdx < numChildren; ++childIdx)
+    static wxString SyntaxHl(const wxString& code, const std::vector<wxString>& cppKeywords) // C++ style (ish)
     {
-        CXComment cmt = clang_Comment_getChild(comment, childIdx);
-        switch (clang_Comment_getKind(cmt))
+        wxString html;
+        html.reserve(code.size());
+        int stRg = 0;
+        int style = wxSCI_C_DEFAULT;
+        const int codeLen = code.Length();
+        for (int enRg = 0; enRg <= codeLen; ++enRg)
         {
-        case CXComment_Null:
-            break;
-
-        case CXComment_Text:
-        {
-            CXString str = clang_TextComment_getText(cmt);
-            doc += Escape(wxString::FromUTF8(clang_getCString(str)));
-            clang_disposeString(str);
-            break;
-        }
-
-        case CXComment_InlineCommand:
-        {
-            size_t numArgs = clang_InlineCommandComment_getNumArgs(cmt);
-            wxString argText;
-            for (size_t argIdx = 0; argIdx < numArgs; ++argIdx)
-            {
-                CXString str = clang_InlineCommandComment_getArgText(cmt, argIdx);
-                argText += Escape(wxString::FromUTF8(clang_getCString(str)));
-                clang_disposeString(str);
-            }
-            switch (clang_InlineCommandComment_getRenderKind(cmt))
+            wxChar ch = (enRg < codeLen ? code[enRg] : wxT('\0'));
+            wxChar nextCh = (enRg < codeLen - 1 ? code[enRg + 1] : wxT('\0'));
+            switch (style)
             {
             default:
-            case CXCommentInlineCommandRenderKind_Normal:
-                doc += argText;
-                break;
-
-            case CXCommentInlineCommandRenderKind_Bold:
-                doc += wxT("<b>") + argText + wxT("</b>");
-                break;
-
-            case CXCommentInlineCommandRenderKind_Monospaced:
-                doc += wxT("<tt>") + argText + wxT("</tt>");
-                break;
-
-            case CXCommentInlineCommandRenderKind_Emphasized:
-                doc += wxT("<em>") + argText + wxT("</em>");
-                break;
-            }
-            break;
-        }
-
-        case CXComment_HTMLStartTag:
-        case CXComment_HTMLEndTag:
-        {
-            CXString str = clang_HTMLTagComment_getAsString(cmt);
-            doc += wxString::FromUTF8(clang_getCString(str));
-            clang_disposeString(str);
-            break;
-        }
-
-        case CXComment_Paragraph:
-            if (!clang_Comment_isWhitespace(cmt))
+            case wxSCI_C_DEFAULT:
             {
-                doc += wxT("<p>");
-                FormatDocumentation(cmt, doc, cppKeywords);
-                doc += wxT("</p>");
-            }
-            break;
-
-        case CXComment_BlockCommand: // TODO: follow the command's instructions
-            FormatDocumentation(cmt, doc, cppKeywords);
-            break;
-
-        case CXComment_ParamCommand:  // TODO
-        case CXComment_TParamCommand: // TODO
-            break;
-
-        case CXComment_VerbatimBlockCommand:
-            doc += wxT("<table cellspacing=\"0\" cellpadding=\"1\" bgcolor=\"black\" width=\"100%\"><tr><td>"
-                    "<table bgcolor=\"white\" width=\"100%\"><tr><td><pre>");
-            FormatDocumentation(cmt, doc, cppKeywords);
-            doc += wxT("</pre></td></tr></table></td></tr></table>");
-            break;
-
-        case CXComment_VerbatimBlockLine:
-        {
-            CXString str = clang_VerbatimBlockLineComment_getText(cmt);
-            wxString codeLine = wxString::FromUTF8(clang_getCString(str));
-            clang_disposeString(str);
-            int endIdx = codeLine.Find(wxT("*/")); // clang will throw in the rest of the file when this happens
-            if (endIdx != wxNOT_FOUND)
-            {
-                endIdx = codeLine.Truncate(endIdx).Find(wxT("\\endcode")); // try to save a bit of grace, and recover what we can
-                if (endIdx == wxNOT_FOUND)
-                {
-                    endIdx = codeLine.Find(wxT("@endcode"));
-                    if (endIdx != wxNOT_FOUND)
-                        codeLine.Truncate(endIdx);
-                }
+                if (wxIsalpha(ch) || ch == wxT('_'))
+                    style = wxSCI_C_IDENTIFIER;
+                else if (wxIsdigit(ch))
+                    style = wxSCI_C_NUMBER;
+                else if (ch == wxT('"'))
+                    style = wxSCI_C_STRING;
+                else if (ch == wxT('\''))
+                    style = wxSCI_C_CHARACTER;
+                else if (ch == wxT('/') && nextCh == wxT('/'))
+                    style = wxSCI_C_COMMENTLINE;
+                else if (wxIspunct(ch))
+                    style = wxSCI_C_OPERATOR;
                 else
-                    codeLine.Truncate(endIdx);
-                doc += SyntaxHl(codeLine, cppKeywords) + wxT("<br><font color=\"red\"><em>__clang_doxygen_parsing_error__</em></font><br>");
-                return; // abort
+                    break;
+                if (stRg != enRg)
+                {
+                    html += Escape(code.Mid(stRg, enRg - stRg));
+                    stRg = enRg;
+                }
+                break;
             }
-            doc += SyntaxHl(codeLine, cppKeywords) + wxT("<br>");
-            break;
-        }
 
-        case CXComment_VerbatimLine:
+            case wxSCI_C_IDENTIFIER:
+            {
+                if (wxIsalnum(ch) || ch == wxT('_'))
+                    break;
+                if (stRg != enRg)
+                {
+                    const wxString& tkn = code.Mid(stRg, enRg - stRg);
+                    if (std::binary_search(cppKeywords.begin(), cppKeywords.end(), tkn))
+                        html += wxT("<b>") + Colourise(Escape(tkn), wxT("#00008b")) + wxT("</b>"); // DarkBlue
+                    else
+                        html += Escape(tkn);
+                    stRg = enRg;
+                    --enRg;
+                }
+                style = wxSCI_C_DEFAULT;
+                break;
+            }
+
+            case wxSCI_C_NUMBER:
+            {
+                if (wxIsalnum(ch))
+                    break;
+                if (stRg != enRg)
+                {
+                    html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("Magenta"));
+                    stRg = enRg;
+                    --enRg;
+                }
+                style = wxSCI_C_DEFAULT;
+                break;
+            }
+
+            case wxSCI_C_STRING:
+            {
+                if (ch == wxT('\\'))
+                {
+                    if (nextCh != wxT('\n'))
+                        ++enRg;
+                    break;
+                }
+                else if (ch && ch != wxT('"') && ch != wxT('\n'))
+                    break;
+                if (stRg != enRg)
+                {
+                    if (ch == wxT('"'))
+                        ++enRg;
+                    html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("#0000cd")); // MediumBlue
+                    stRg = enRg;
+                    --enRg;
+                }
+                style = wxSCI_C_DEFAULT;
+                break;
+            }
+
+            case wxSCI_C_CHARACTER:
+            {
+                if (ch == wxT('\\'))
+                {
+                    if (nextCh != wxT('\n'))
+                        ++enRg;
+                    break;
+                }
+                else if (ch && ch != wxT('\'') && ch != wxT('\n'))
+                    break;
+                if (stRg != enRg)
+                {
+                    if (ch == wxT('\''))
+                        ++enRg;
+                    html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("GoldenRod"));
+                    stRg = enRg;
+                    --enRg;
+                }
+                style = wxSCI_C_DEFAULT;
+                break;
+            }
+
+            case wxSCI_C_COMMENTLINE:
+            {
+                if (ch && ch != wxT('\n'))
+                    break;
+                if (stRg != enRg)
+                {
+                    html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("#778899")); // LightSlateGray
+                    stRg = enRg;
+                }
+                style = wxSCI_C_DEFAULT;
+                break;
+            }
+
+            case wxSCI_C_OPERATOR:
+            {
+                if (wxIspunct(ch) && ch != wxT('"') && ch != wxT('\'') && ch != wxT('_'))
+                    break;
+                if (stRg != enRg)
+                {
+                    html += Colourise(Escape(code.Mid(stRg, enRg - stRg)), wxT("Red"));
+                    stRg = enRg;
+                    --enRg;
+                }
+                style = wxSCI_C_DEFAULT;
+                break;
+            }
+            }
+        }
+        return html;
+    }
+
+    static void FormatDocumentation(CXComment comment, wxString& doc, const std::vector<wxString>& cppKeywords)
+    {
+        size_t numChildren = clang_Comment_getNumChildren(comment);
+        for (size_t childIdx = 0; childIdx < numChildren; ++childIdx)
         {
-            CXString str = clang_VerbatimLineComment_getText(cmt);
-            doc += wxT("<pre>") + Escape(wxString::FromUTF8(clang_getCString(str))) + wxT("</pre>"); // TODO: syntax highlight
-            clang_disposeString(str);
-            break;
-        }
+            CXComment cmt = clang_Comment_getChild(comment, childIdx);
+            switch (clang_Comment_getKind(cmt))
+            {
+            case CXComment_Null:
+                break;
 
-        case CXComment_FullComment: // ignore?
-        default:
-            break;
+            case CXComment_Text:
+            {
+                CXString str = clang_TextComment_getText(cmt);
+                doc += Escape(wxString::FromUTF8(clang_getCString(str)));
+                clang_disposeString(str);
+                break;
+            }
+
+            case CXComment_InlineCommand:
+            {
+                size_t numArgs = clang_InlineCommandComment_getNumArgs(cmt);
+                wxString argText;
+                for (size_t argIdx = 0; argIdx < numArgs; ++argIdx)
+                {
+                    CXString str = clang_InlineCommandComment_getArgText(cmt, argIdx);
+                    argText += Escape(wxString::FromUTF8(clang_getCString(str)));
+                    clang_disposeString(str);
+                }
+                switch (clang_InlineCommandComment_getRenderKind(cmt))
+                {
+                default:
+                case CXCommentInlineCommandRenderKind_Normal:
+                    doc += argText;
+                    break;
+
+                case CXCommentInlineCommandRenderKind_Bold:
+                    doc += wxT("<b>") + argText + wxT("</b>");
+                    break;
+
+                case CXCommentInlineCommandRenderKind_Monospaced:
+                    doc += wxT("<tt>") + argText + wxT("</tt>");
+                    break;
+
+                case CXCommentInlineCommandRenderKind_Emphasized:
+                    doc += wxT("<em>") + argText + wxT("</em>");
+                    break;
+                }
+                break;
+            }
+
+            case CXComment_HTMLStartTag:
+            case CXComment_HTMLEndTag:
+            {
+                CXString str = clang_HTMLTagComment_getAsString(cmt);
+                doc += wxString::FromUTF8(clang_getCString(str));
+                clang_disposeString(str);
+                break;
+            }
+
+            case CXComment_Paragraph:
+                if (!clang_Comment_isWhitespace(cmt))
+                {
+                    doc += wxT("<p>");
+                    FormatDocumentation(cmt, doc, cppKeywords);
+                    doc += wxT("</p>");
+                }
+                break;
+
+            case CXComment_BlockCommand: // TODO: follow the command's instructions
+                FormatDocumentation(cmt, doc, cppKeywords);
+                break;
+
+            case CXComment_ParamCommand:  // TODO
+            case CXComment_TParamCommand: // TODO
+                break;
+
+            case CXComment_VerbatimBlockCommand:
+                doc += wxT("<table cellspacing=\"0\" cellpadding=\"1\" bgcolor=\"black\" width=\"100%\"><tr><td>"
+                        "<table bgcolor=\"white\" width=\"100%\"><tr><td><pre>");
+                FormatDocumentation(cmt, doc, cppKeywords);
+                doc += wxT("</pre></td></tr></table></td></tr></table>");
+                break;
+
+            case CXComment_VerbatimBlockLine:
+            {
+                CXString str = clang_VerbatimBlockLineComment_getText(cmt);
+                wxString codeLine = wxString::FromUTF8(clang_getCString(str));
+                clang_disposeString(str);
+                int endIdx = codeLine.Find(wxT("*/")); // clang will throw in the rest of the file when this happens
+                if (endIdx != wxNOT_FOUND)
+                {
+                    endIdx = codeLine.Truncate(endIdx).Find(wxT("\\endcode")); // try to save a bit of grace, and recover what we can
+                    if (endIdx == wxNOT_FOUND)
+                    {
+                        endIdx = codeLine.Find(wxT("@endcode"));
+                        if (endIdx != wxNOT_FOUND)
+                            codeLine.Truncate(endIdx);
+                    }
+                    else
+                        codeLine.Truncate(endIdx);
+                    doc += SyntaxHl(codeLine, cppKeywords) + wxT("<br><font color=\"red\"><em>__clang_doxygen_parsing_error__</em></font><br>");
+                    return; // abort
+                }
+                doc += SyntaxHl(codeLine, cppKeywords) + wxT("<br>");
+                break;
+            }
+
+            case CXComment_VerbatimLine:
+            {
+                CXString str = clang_VerbatimLineComment_getText(cmt);
+                doc += wxT("<pre>") + Escape(wxString::FromUTF8(clang_getCString(str))) + wxT("</pre>"); // TODO: syntax highlight
+                clang_disposeString(str);
+                break;
+            }
+
+            case CXComment_FullComment: // ignore?
+            default:
+                break;
+            }
         }
     }
-}
 }
 
 ClangProxy::ClangProxy( wxEvtHandler* pEvtCallbackHandler, TokenDatabase& database, const std::vector<wxString>& cppKeywords):
@@ -581,11 +581,9 @@ ClangProxy::ClangProxy( wxEvtHandler* pEvtCallbackHandler, TokenDatabase& databa
     m_ConditionQueueNotEmpty(m_TaskQueueMutex)
 {
     m_ClIndex = clang_createIndex(0, 0);
-#if CLANGPROXY_USE_THREAD
     m_pThread = new TaskThread(this);
     m_pThread->Create();
     m_pThread->Run();
-#endif
 }
 
 ClangProxy::~ClangProxy()
@@ -625,7 +623,8 @@ int ClangProxy::GetTranslationUnitId(FileId fId)
     wxMutexLocker locker(m_Mutex);
     for (size_t i = 0; i < m_TranslUnits.size(); ++i)
     {
-        if (m_TranslUnits[i].Contains(fId)){
+        if (m_TranslUnits[i].Contains(fId))
+        {
             //std::cout<<"TranslUnits index "<<i<<" has file id "<<fId<<std::endl;
             return i;
         }
@@ -665,8 +664,8 @@ void ClangProxy::CodeCompleteAt(bool isAuto, const wxString& filename,
     }
     wxMutexLocker locker(m_Mutex);
     CXCodeCompleteResults* clResults = m_TranslUnits[translId].CodeCompleteAt(chName.data(), line, column,
-                clUnsavedFiles.empty() ? nullptr : &clUnsavedFiles[0],
-                clUnsavedFiles.size());
+            clUnsavedFiles.empty() ? nullptr : &clUnsavedFiles[0],
+            clUnsavedFiles.size());
     if (!clResults)
     {
         fprintf(stdout,"%s No results...\n", __PRETTY_FUNCTION__);
@@ -1243,7 +1242,8 @@ wxThread::ExitCode ClangProxy::TaskThread::Entry()
         Task* pTask = NULL;
         {
             wxMutexLocker lock(m_pClangProxy->m_TaskQueueMutex);
-            while(m_pClangProxy->m_TaskQueue.empty()){
+            while(m_pClangProxy->m_TaskQueue.empty())
+            {
                 wxCondError err = m_pClangProxy->m_ConditionQueueNotEmpty.Wait();
                 if( err != wxCOND_NO_ERROR )
                 {
@@ -1256,15 +1256,18 @@ wxThread::ExitCode ClangProxy::TaskThread::Entry()
         }
         if( pTask )
         {
-            try{
+            try
+            {
                 (*pTask)(*m_pClangProxy);
-            }catch(...)
+            }
+            catch(...)
             {
                 fprintf(stdout,"%s: Exception caught\n", __PRETTY_FUNCTION__);
                 continue;
             }
             pTask->Completed();
-            if( m_pClangProxy->m_pEventCallbackHandler ){
+            if( m_pClangProxy->m_pEventCallbackHandler )
+            {
                 if( pTask->GetCallbackEventType() != 0 )
                 {
                     ClangProxy::CallbackEvent evt( pTask->GetCallbackEventType(), pTask->GetCallbackEventId(), pTask);

--- a/clangproxy.h
+++ b/clangproxy.h
@@ -3,10 +3,16 @@
 
 #include <map>
 #include <vector>
+#include <list>
 #include <wx/string.h>
+#include <queue>
+
+#undef CLANGPROXY_TRACE_FUNCTIONS
 
 class TranslationUnit;
 class TokenDatabase;
+class ClangProxy;
+
 typedef void* CXIndex;
 typedef int FileId;
 
@@ -70,37 +76,435 @@ struct ClDiagnostic
 
 class ClangProxy
 {
+public:
+    /*abstract */class Task : public wxObject
+    {
+    protected:
+        Task( wxEventType evtType, int evtId ) : wxObject(), m_EventType(evtType), m_EventId(evtId)
+        {
+        }
+        Task( const Task& other ) : wxObject()
+        {
+            m_EventType = other.m_EventType;
+            m_EventId = other.m_EventId;
+        }
+
     public:
-        ClangProxy(TokenDatabase& database, const std::vector<wxString>& cppKeywords);
-        ~ClangProxy();
+        virtual Task* Clone() const = 0;
+        virtual void operator()(ClangProxy& clangproxy) {}
+        virtual void Completed(){}
+        wxEventType GetCallbackEventType() const { return m_EventType; }
+        int GetCallbackEventId() const { return m_EventId; }
 
-        void CreateTranslationUnit(const wxString& filename, const wxString& commands);
-        int GetTranslationUnitId(FileId fId);
-        int GetTranslationUnitId(const wxString& filename);
+    protected:
+        wxEventType m_EventType;
+        int         m_EventId;
+    };
 
-        void CodeCompleteAt(bool isAuto, const wxString& filename, int line, int column, int translId,
-                            const std::map<wxString, wxString>& unsavedFiles, std::vector<ClToken>& results);
-        wxString DocumentCCToken(int translId, int tknId);
-        wxString GetCCInsertSuffix(int translId, int tknId, const wxString& newLine, std::pair<int, int>& offsets);
-        void RefineTokenType(int translId, int tknId, int& tknType); // TODO: cache TokenId (if resolved) for DocumentCCToken()
+    class CreateTranslationUnitTask : public Task
+    {
+    public:
+        CreateTranslationUnitTask( wxEventType evtType, int evtId, const wxString& filename, const wxString& commands ) :
+            Task(evtType, evtId),
+            m_Filename(filename),
+            m_Commands(commands),
+            m_TranslationUnitId(0){}
+        Task* Clone() const
+        {
+            CreateTranslationUnitTask* task = new CreateTranslationUnitTask(m_EventType, m_EventId, m_Filename, m_Commands);
+            task->m_TranslationUnitId = m_TranslationUnitId;
+            return static_cast<Task*>(task);
+        }
+        void operator()(ClangProxy& clangproxy)
+        {
+#ifdef CLANGPROXY_TRACE_FUNCTIONS
+            fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+#endif
+            clangproxy.CreateTranslationUnit(m_Filename, m_Commands);
+            m_TranslationUnitId = clangproxy.GetTranslationUnitId(m_Filename);
+        }
+    public:
+        wxString m_Filename;
+        wxString m_Commands;
+        int m_TranslationUnitId; // Returned value
+    };
 
-        void GetCallTipsAt(const wxString& filename, int line, int column, int translId,
-                           const wxString& tokenStr, std::vector<wxStringVec>& results);
+    class ReparseTask : public Task
+    {
+    public:
+        ReparseTask( wxEventType evtType, int evtId, int translId, const std::map<wxString, wxString>& unsavedFiles )
+            : Task(evtType, evtId),
+              m_TranslId(translId),
+              m_UnsavedFiles(unsavedFiles)
+        {}
+        Task* Clone() const
+        {
+            return new ReparseTask(m_EventType, m_EventId, m_TranslId, m_UnsavedFiles);
+        }
+        void operator()(ClangProxy& clangproxy)
+        {
+#ifdef CLANGPROXY_TRACE_FUNCTIONS
+            fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+#endif
+            clangproxy.Reparse(m_TranslId, m_UnsavedFiles);
+        }
+    public:
+        int m_TranslId;
+        std::map<wxString, wxString> m_UnsavedFiles;
+    };
 
-        void GetTokensAt(const wxString& filename, int line, int column, int translId, std::vector<wxString>& results);
-        void GetOccurrencesOf(const wxString& filename, int line, int column,
-                              int translId, std::vector< std::pair<int, int> >& results);
-        void ResolveTokenAt(wxString& filename, int& line, int& column, int translId);
+    class GetDiagnosticsTask : public Task
+    {
+    public:
+        GetDiagnosticsTask( wxEventType evtType, int evtId, int translId ):
+            Task(evtType, evtId),
+            m_TranslId(translId)
+        {}
+        Task* Clone() const
+        {
+            GetDiagnosticsTask* pTask = new GetDiagnosticsTask(m_EventType, m_EventId, m_TranslId);
+            pTask->m_Diagnostics = m_Diagnostics;
+            return static_cast<Task*>(pTask);
+        }
+        void operator()(ClangProxy& clangproxy)
+        {
+#ifdef CLANGPROXY_TRACE_FUNCTIONS
+            fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+#endif
+            clangproxy.GetDiagnostics(m_TranslId, m_Diagnostics);
+        }
+    public:
+        int m_TranslId;
+        std::vector<ClDiagnostic> m_Diagnostics; // Returned value
+    };
 
-        void Reparse(int translId, const std::map<wxString, wxString>& unsavedFiles);
+    // Task designed to be run synchronous
+    /*abstract */class SyncTask : public Task
+    {
+    protected:
+        SyncTask(wxEventType evtType, int evtId) :
+            Task(evtType, evtId),
+            m_bCompleted(false),
+            m_pMutex(new wxMutex()),
+            m_pCond(new wxCondition(*m_pMutex)){
+            }
+        SyncTask(wxEventType evtType, int evtId, wxMutex* pMutex, wxCondition* pCond) :
+            Task(evtType, evtId),
+            m_bCompleted(false),
+            m_pMutex(pMutex),
+            m_pCond(pCond){}
+    public:
+        // Called on task thread
+        virtual void Completed()
+        {
+#ifdef CLANGPROXY_TRACE_FUNCTIONS
+            fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+#endif
+            wxMutexLocker lock(*m_pMutex);
+            m_bCompleted = true;
+            m_pCond->Signal();
+        }
+        // Called on main thread
+        wxCondError WaitCompletion( unsigned long milliseconds )
+        {
+#ifdef CLANGPROXY_TRACE_FUNCTIONS
+            fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+#endif
+            wxMutexLocker lock(*m_pMutex);
+            if( m_bCompleted ){
+                return wxCOND_NO_ERROR;
+            }
+            return m_pCond->WaitTimeout(milliseconds);
+        }
+        // Called on main thread
+        virtual void Finalize()
+        {
+#ifdef CLANGPROXY_TRACE_FUNCTIONS
+            fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+#endif
+            m_pMutex->Unlock();
+            delete m_pMutex;
+            m_pMutex = NULL;
+            delete m_pCond;
+            m_pCond = NULL;
+        }
+protected:
+        bool m_bCompleted;
+        mutable wxMutex* m_pMutex;
+        mutable wxCondition* m_pCond;
+    };
 
-        void GetDiagnostics(int translId, std::vector<ClDiagnostic>& diagnostics);
+    class CodeCompleteAtTask : public SyncTask
+    {
+    public:
+        CodeCompleteAtTask( wxEventType evtType, int evtId, bool isAuto,
+                const wxString& filename, int line, int column,
+                int translId, const std::map<wxString, wxString>& unsavedFiles ):
+            SyncTask(evtType, evtId),
+            m_IsAuto(isAuto),
+            m_Filename(filename),
+            m_Line(line),
+            m_Column(column),
+            m_TranslId(translId),
+            m_UnsavedFiles(unsavedFiles)
+        {
+            m_pResults = new std::vector<ClToken>();
+        }
 
-    private:
-        TokenDatabase& m_Database;
-        const std::vector<wxString>& m_CppKeywords;
-        std::vector<TranslationUnit> m_TranslUnits;
-        CXIndex m_ClIndex;
+        Task* Clone() const
+        {
+            CodeCompleteAtTask* pTask = new CodeCompleteAtTask(m_EventType, m_EventId, m_IsAuto, m_Filename, m_Line, m_Column, m_TranslId, m_UnsavedFiles, m_pMutex, m_pCond, m_pResults);
+            return static_cast<Task*>(pTask);
+        }
+        void operator()(ClangProxy& clangproxy)
+        {
+#ifdef CLANGPROXY_TRACE_FUNCTIONS
+            fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+#endif
+            std::vector<ClToken> results;
+            clangproxy.CodeCompleteAt( m_IsAuto, m_Filename, m_Line, m_Column, m_TranslId, m_UnsavedFiles, results);
+            m_pResults->swap(results);
+        }
+        virtual void Finalize()
+        {
+            SyncTask::Finalize();
+            delete m_pResults;
+        }
+        const std::vector<ClToken>& GetResults(){ return *m_pResults; }
+    protected:
+        CodeCompleteAtTask( wxEventType evtType, int evtId, bool isAuto,
+                const wxString& filename, int line, int column,
+                int translId, const std::map<wxString, wxString>& unsavedFiles,
+                wxMutex* pMutex, wxCondition* pCond,
+                std::vector<ClToken>* pResults ):
+            SyncTask(evtType, evtId, pMutex, pCond),
+            m_IsAuto(isAuto),
+            m_Filename(filename),
+            m_Line(line),
+            m_Column(column),
+            m_TranslId(translId),
+            m_UnsavedFiles(unsavedFiles),
+            m_pResults(pResults){}
+        bool m_IsAuto;
+        wxString m_Filename;
+        int m_Line;
+        int m_Column;
+        int m_TranslId;
+        std::map<wxString, wxString> m_UnsavedFiles;
+        std::vector<ClToken>* m_pResults; // Returned value
+    };
+
+    class GetTokensAtTask : public SyncTask
+    {
+    public:
+        GetTokensAtTask( wxEventType evtType, int evtId, const wxString& filename, int line, int column, int translId ):
+            SyncTask(evtType, evtId),
+            m_Filename(filename),
+            m_Line(line),
+            m_Column(column),
+            m_TranslId(translId) {
+                m_pResults = new wxStringVec();
+            }
+        Task* Clone() const
+        {
+            GetTokensAtTask* pTask = new GetTokensAtTask(m_EventType, m_EventId, m_Filename, m_Line, m_Column, m_TranslId, m_pMutex, m_pCond, m_pResults);
+            return static_cast<Task*>(pTask);
+        }
+        void operator()(ClangProxy& clangproxy)
+        {
+#ifdef CLANGPROXY_TRACE_FUNCTIONS
+            fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+#endif
+            clangproxy.GetTokensAt( m_Filename, m_Line, m_Column, m_TranslId, *m_pResults);
+        }
+        const wxStringVec& GetResults(){ return *m_pResults; }
+    protected:
+        GetTokensAtTask( wxEventType evtType, int evtId, const wxString& filename, int line, int column, int translId,
+                wxMutex* pMutex, wxCondition* pCond,
+                wxStringVec* pResults ):
+            SyncTask(evtType, evtId, pMutex, pCond),
+            m_Filename(filename),
+            m_Line(line),
+            m_Column(column),
+            m_TranslId(translId),
+            m_pResults(pResults){}
+        wxString m_Filename;
+        int m_Line;
+        int m_Column;
+        int m_TranslId;
+        wxStringVec* m_pResults;
+    };
+
+    class GetCallTipsAtTask : public SyncTask
+    {
+    public:
+        GetCallTipsAtTask( wxEventType evtType, int evtId, const wxString& filename, int line, int column, int translId, const wxString& tokenStr ):
+            SyncTask(evtType, evtId),
+            m_Filename(filename),
+            m_Line(line),
+            m_Column(column),
+            m_TranslId(translId),
+            m_TokenStr(tokenStr) {
+            m_pResults = new std::vector<wxStringVec>();
+            }
+        Task* Clone() const
+        {
+            GetCallTipsAtTask* pTask = new GetCallTipsAtTask(m_EventType, m_EventId, m_Filename, m_Line, m_Column, m_TranslId, m_TokenStr, m_pMutex, m_pCond, m_pResults);
+            return static_cast<Task*>(pTask);
+        }
+        void operator()(ClangProxy& clangproxy)
+        {
+#ifdef CLANGPROXY_TRACE_FUNCTIONS
+            fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+#endif
+            clangproxy.GetCallTipsAt( m_Filename, m_Line, m_Column, m_TranslId, m_TokenStr, *m_pResults);
+        }
+        const std::vector<wxStringVec>& GetResults(){ return *m_pResults; }
+    protected:
+        GetCallTipsAtTask( wxEventType evtType, int evtId, const wxString& filename, int line, int column, int translId, const wxString& tokenStr,
+                wxMutex* pMutex, wxCondition* pCond,
+                std::vector<wxStringVec>* pResults ):
+            SyncTask(evtType, evtId, pMutex, pCond),
+            m_Filename(filename),
+            m_Line(line),
+            m_Column(column),
+            m_TranslId(translId),
+            m_TokenStr(tokenStr),
+            m_pResults(pResults){}
+        wxString m_Filename;
+        int m_Line;
+        int m_Column;
+        int m_TranslId;
+        wxString m_TokenStr;
+        std::vector<wxStringVec>* m_pResults;
+    };
+
+    class GetOccurrencesOfTask : public SyncTask
+    {
+    public:
+        GetOccurrencesOfTask( wxEventType evtType, int evtId, const wxString& filename, int line, int column, int translId ):
+            SyncTask(evtType, evtId),
+            m_Filename(filename),
+            m_Line(line),
+            m_Column(column),
+            m_TranslId(translId) {
+                m_pResults = new std::vector< std::pair<int, int> >();
+            }
+        Task* Clone() const
+        {
+            GetOccurrencesOfTask* pTask = new GetOccurrencesOfTask(m_EventType, m_EventId, m_Filename, m_Line, m_Column, m_TranslId, m_pMutex, m_pCond, m_pResults);
+            return static_cast<Task*>(pTask);
+        }
+        void operator()(ClangProxy& clangproxy)
+        {
+#ifdef CLANGPROXY_TRACE_FUNCTIONS
+            fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+#endif
+            clangproxy.GetOccurrencesOf( m_Filename, m_Line, m_Column, m_TranslId, *m_pResults);
+        }
+        const std::vector< std::pair<int, int> >& GetResults(){ return *m_pResults; }
+    protected:
+        GetOccurrencesOfTask( wxEventType evtType, int evtId, const wxString& filename, int line, int column, int translId,
+                wxMutex* pMutex, wxCondition* pCond,
+                std::vector< std::pair<int, int> >* pResults ):
+            SyncTask(evtType, evtId, pMutex, pCond),
+            m_Filename(filename),
+            m_Line(line),
+            m_Column(column),
+            m_TranslId(translId),
+            m_pResults(pResults){}
+        wxString m_Filename;
+        int m_Line;
+        int m_Column;
+        int m_TranslId;
+        std::vector< std::pair<int, int> >* m_pResults;
+    };
+
+
+    /**
+     * Helper class that manages the lifecycle of the Get/SetEventObject() object when passing threads
+     */
+    class CallbackEvent : public wxEvent
+    {
+    public:
+        CallbackEvent( wxEventType evtType, int evtId, Task* task ) : wxEvent( evtType, evtId )
+        {
+            SetEventObject(task);
+        }
+        CallbackEvent( const CallbackEvent& src )
+        {
+            ClangProxy::Task* pTask = static_cast<ClangProxy::Task*>(src.GetEventObject());
+            if (pTask)
+                SetEventObject( pTask->Clone() );
+        }
+        ~CallbackEvent()
+        {
+            wxObject* obj = GetEventObject();
+            delete obj;
+        }
+        wxEvent* Clone() const
+        {
+            ClangProxy::Task* pTask = static_cast<ClangProxy::Task*>(GetEventObject());
+            if( pTask )
+                pTask = pTask->Clone();
+            return new CallbackEvent( m_eventType, m_id, pTask );
+        }
+    };
+
+
+    class TaskThread : public wxThread
+    {
+    public:
+        TaskThread( ClangProxy* pClangProxy ) :
+            wxThread(wxTHREAD_DETACHED),
+            m_pClangProxy(pClangProxy) {}
+
+        wxThread::ExitCode Entry();
+    public:
+        ClangProxy* m_pClangProxy;
+    };
+
+public:
+    ClangProxy( wxEvtHandler* pEvtHandler, TokenDatabase& database, const std::vector<wxString>& cppKeywords);
+    ~ClangProxy();
+
+    void AddPendingTask( ClangProxy::Task& task );
+
+    int GetTranslationUnitId(FileId fId);
+    int GetTranslationUnitId(const wxString& filename);
+
+protected: // Tasks that are run only on the thread
+    void CreateTranslationUnit(const wxString& filename, const wxString& commands);
+    void Reparse(int translId, const std::map<wxString, wxString>& unsavedFiles);
+    void GetDiagnostics(int translId, std::vector<ClDiagnostic>& diagnostics);
+    void CodeCompleteAt(bool isAuto, const wxString& filename, int line, int column, int translId,
+            const std::map<wxString, wxString>& unsavedFiles, std::vector<ClToken>& results);
+    void GetTokensAt(const wxString& filename, int line, int column, int translId, std::vector<wxString>& results);
+    void GetCallTipsAt(const wxString& filename, int line, int column, int translId,
+            const wxString& tokenStr, std::vector<wxStringVec>& results);
+    void GetOccurrencesOf(const wxString& filename, int line, int column,
+            int translId, std::vector< std::pair<int, int> >& results);
+
+public:
+    wxString DocumentCCToken(int translId, int tknId);
+    wxString GetCCInsertSuffix(int translId, int tknId, const wxString& newLine, std::pair<int, int>& offsets);
+    void RefineTokenType(int translId, int tknId, int& tknType); // TODO: cache TokenId (if resolved) for DocumentCCToken()
+
+
+    void ResolveDeclTokenAt(wxString& filename, int& line, int& column, int translId);
+
+private:
+    mutable wxMutex m_Mutex;
+    TokenDatabase& m_Database;
+    const std::vector<wxString>& m_CppKeywords;
+    std::vector<TranslationUnit> m_TranslUnits;
+    CXIndex m_ClIndex;
+private: // Thread
+    mutable wxMutex m_TaskQueueMutex; // Protects: m_TaskQueue
+    wxEvtHandler* m_pEventCallbackHandler;
+    std::queue<ClangProxy::Task*> m_TaskQueue;
+    mutable wxCondition m_ConditionQueueNotEmpty;
+    TaskThread* m_pThread;
 };
 
 #endif // CLANGPROXY_H

--- a/tokendatabase.cpp
+++ b/tokendatabase.cpp
@@ -14,19 +14,16 @@ TokenDatabase::TokenDatabase() :
     m_pTokens(new TreeMap<AbstractToken>()),
     m_pFilenames(new TreeMap<wxString>())
 {
-    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
 }
 
 TokenDatabase::~TokenDatabase()
 {
-    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     delete m_pFilenames;
     delete m_pTokens;
 }
 
 FileId TokenDatabase::GetFilenameId(const wxString& filename)
 {
-    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
     wxFileName fln(filename);
     fln.Normalize(wxPATH_NORM_ALL & ~wxPATH_NORM_CASE);
     const wxString& normFile = fln.GetFullPath(wxPATH_UNIX);
@@ -38,15 +35,12 @@ FileId TokenDatabase::GetFilenameId(const wxString& filename)
 
 wxString TokenDatabase::GetFilename(FileId fId) const
 {
-    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
     return m_pFilenames->GetValue(fId);
 }
 
 TokenId TokenDatabase::InsertToken(const wxString& identifier, const AbstractToken& token)
 {
-    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
     TokenId tId = GetTokenId(identifier, token.tokenHash);
-    //wxMutexLocker locker(m_Mutex);
     if (tId == wxNOT_FOUND)
         return m_pTokens->Insert(identifier, token);
     return tId;
@@ -54,12 +48,9 @@ TokenId TokenDatabase::InsertToken(const wxString& identifier, const AbstractTok
 
 TokenId TokenDatabase::GetTokenId(const wxString& identifier, unsigned tokenHash) const
 {
-    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
-    //wxMutexLocker locker(m_Mutex);
-    //std::cout<<__PRETTY_FUNCTION__<<" acquired lock"<<std::endl;
     std::vector<int> ids = m_pTokens->GetIdSet(identifier);
     for (std::vector<int>::const_iterator itr = ids.begin();
-         itr != ids.end(); ++itr)
+            itr != ids.end(); ++itr)
     {
         if (m_pTokens->GetValue(*itr).tokenHash == tokenHash)
             return *itr;
@@ -69,22 +60,16 @@ TokenId TokenDatabase::GetTokenId(const wxString& identifier, unsigned tokenHash
 
 AbstractToken& TokenDatabase::GetToken(TokenId tId) const
 {
-    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
-    //wxMutexLocker locker(m_Mutex);
     return m_pTokens->GetValue(tId);
 }
 
 std::vector<TokenId> TokenDatabase::GetTokenMatches(const wxString& identifier) const
 {
-    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
-    //wxMutexLocker locker(m_Mutex);
     return m_pTokens->GetIdSet(identifier);
 }
 
 void TokenDatabase::Shrink()
 {
-    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
     m_pFilenames->Shrink();
-    //wxMutexLocker locker(m_Mutex);
     m_pTokens->Shrink();
 }

--- a/tokendatabase.cpp
+++ b/tokendatabase.cpp
@@ -6,6 +6,7 @@
 
 #include <wx/filename.h>
 #include <wx/string.h>
+#include <iostream>
 
 #include "treemap.h"
 
@@ -13,16 +14,19 @@ TokenDatabase::TokenDatabase() :
     m_pTokens(new TreeMap<AbstractToken>()),
     m_pFilenames(new TreeMap<wxString>())
 {
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
 }
 
 TokenDatabase::~TokenDatabase()
 {
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     delete m_pFilenames;
     delete m_pTokens;
 }
 
 FileId TokenDatabase::GetFilenameId(const wxString& filename)
 {
+    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
     wxFileName fln(filename);
     fln.Normalize(wxPATH_NORM_ALL & ~wxPATH_NORM_CASE);
     const wxString& normFile = fln.GetFullPath(wxPATH_UNIX);
@@ -34,12 +38,15 @@ FileId TokenDatabase::GetFilenameId(const wxString& filename)
 
 wxString TokenDatabase::GetFilename(FileId fId) const
 {
+    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
     return m_pFilenames->GetValue(fId);
 }
 
 TokenId TokenDatabase::InsertToken(const wxString& identifier, const AbstractToken& token)
 {
+    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
     TokenId tId = GetTokenId(identifier, token.tokenHash);
+    //wxMutexLocker locker(m_Mutex);
     if (tId == wxNOT_FOUND)
         return m_pTokens->Insert(identifier, token);
     return tId;
@@ -47,6 +54,9 @@ TokenId TokenDatabase::InsertToken(const wxString& identifier, const AbstractTok
 
 TokenId TokenDatabase::GetTokenId(const wxString& identifier, unsigned tokenHash) const
 {
+    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
+    //wxMutexLocker locker(m_Mutex);
+    //std::cout<<__PRETTY_FUNCTION__<<" acquired lock"<<std::endl;
     std::vector<int> ids = m_pTokens->GetIdSet(identifier);
     for (std::vector<int>::const_iterator itr = ids.begin();
          itr != ids.end(); ++itr)
@@ -59,16 +69,22 @@ TokenId TokenDatabase::GetTokenId(const wxString& identifier, unsigned tokenHash
 
 AbstractToken& TokenDatabase::GetToken(TokenId tId) const
 {
+    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
+    //wxMutexLocker locker(m_Mutex);
     return m_pTokens->GetValue(tId);
 }
 
 std::vector<TokenId> TokenDatabase::GetTokenMatches(const wxString& identifier) const
 {
+    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
+    //wxMutexLocker locker(m_Mutex);
     return m_pTokens->GetIdSet(identifier);
 }
 
 void TokenDatabase::Shrink()
 {
+    //std::cout<<__PRETTY_FUNCTION__<<std::endl;
     m_pFilenames->Shrink();
+    //wxMutexLocker locker(m_Mutex);
     m_pTokens->Shrink();
 }

--- a/tokendatabase.h
+++ b/tokendatabase.h
@@ -22,24 +22,23 @@ struct AbstractToken
 
 class TokenDatabase
 {
-    public:
-        TokenDatabase();
-        ~TokenDatabase();
+public:
+    TokenDatabase();
+    ~TokenDatabase();
 
-        FileId GetFilenameId(const wxString& filename);
-        wxString GetFilename(FileId fId) const;
+    FileId GetFilenameId(const wxString& filename);
+    wxString GetFilename(FileId fId) const;
 
-        TokenId InsertToken(const wxString& identifier, const AbstractToken& token); // duplicate tokens are discarded
-        TokenId GetTokenId(const wxString& identifier, unsigned tokenHash) const; // returns wxNOT_FOUND on failure
-        AbstractToken& GetToken(TokenId tId) const;
-        std::vector<TokenId> GetTokenMatches(const wxString& identifier) const;
+    TokenId InsertToken(const wxString& identifier, const AbstractToken& token); // duplicate tokens are discarded
+    TokenId GetTokenId(const wxString& identifier, unsigned tokenHash) const; // returns wxNOT_FOUND on failure
+    AbstractToken& GetToken(TokenId tId) const;
+    std::vector<TokenId> GetTokenMatches(const wxString& identifier) const;
 
-        void Shrink();
+    void Shrink();
 
-    private:
-        TreeMap<AbstractToken>* m_pTokens;
-        TreeMap<wxString>* m_pFilenames;
-        //mutable wxMutex     m_Mutex;
+private:
+    TreeMap<AbstractToken>* m_pTokens;
+    TreeMap<wxString>* m_pFilenames;
 };
 
 #endif // TOKENDATABASE_H

--- a/tokendatabase.h
+++ b/tokendatabase.h
@@ -2,6 +2,7 @@
 #define TOKENDATABASE_H
 
 #include <vector>
+#include <wx/thread.h>
 
 template<typename _Tp> class TreeMap;
 class wxString;
@@ -38,6 +39,7 @@ class TokenDatabase
     private:
         TreeMap<AbstractToken>* m_pTokens;
         TreeMap<wxString>* m_pFilenames;
+        //mutable wxMutex     m_Mutex;
 };
 
 #endif // TOKENDATABASE_H

--- a/translationunit.cpp
+++ b/translationunit.cpp
@@ -7,29 +7,32 @@
 #include "translationunit.h"
 
 #ifndef CB_PRECOMP
-    #include <cbexception.h> // for cbThrow()
+#include <cbexception.h> // for cbThrow()
 
-    #include <algorithm>
+#include <algorithm>
 #endif // CB_PRECOMP
 
 #include "tokendatabase.h"
 
 static void ClInclusionVisitor(CXFile included_file, CXSourceLocation* inclusion_stack,
-                               unsigned include_len, CXClientData client_data);
+        unsigned include_len, CXClientData client_data);
 
 static CXChildVisitResult ClAST_Visitor(CXCursor cursor, CXCursor parent, CXClientData client_data);
 
 TranslationUnit::TranslationUnit(const wxString& filename, const std::vector<const char*>& args,
-                                 CXIndex clIndex, TokenDatabase* database) :
+        CXIndex clIndex, TokenDatabase* database) :
     m_LastCC(nullptr),
-    m_LastPos(-1, -1)
+    m_LastPos(-1, -1),
+    m_Mutex()
 {
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     // TODO: check and handle error conditions
     m_ClTranslUnit = clang_parseTranslationUnit( clIndex, filename.ToUTF8().data(), args.empty() ? nullptr : &args[0],
-                                                 args.size(), nullptr, 0,
-                                                   clang_defaultEditingTranslationUnitOptions()
-                                                 | CXTranslationUnit_IncludeBriefCommentsInCodeCompletion
-                                                 | CXTranslationUnit_DetailedPreprocessingRecord );
+            args.size(), nullptr, 0,
+            clang_defaultEditingTranslationUnitOptions()
+            | CXTranslationUnit_IncludeBriefCommentsInCodeCompletion
+            | CXTranslationUnit_DetailedPreprocessingRecord );
+    fprintf(stdout,"%s clang_parseTranslationUnit done\n", __PRETTY_FUNCTION__);
     std::pair<TranslationUnit*, TokenDatabase*> visitorData = std::make_pair(this, database);
     clang_getInclusions(m_ClTranslUnit, ClInclusionVisitor, &visitorData);
     m_Files.reserve(1024);
@@ -41,10 +44,14 @@ TranslationUnit::TranslationUnit(const wxString& filename, const std::vector<con
 #else
     std::vector<FileId>(m_Files).swap(m_Files);
 #endif
+    fprintf(stdout,"%s calling Reparse()\n", __PRETTY_FUNCTION__);
     Reparse(0, nullptr); // seems to improve performance for some reason?
 
+    fprintf(stdout,"%s calling VisitChildren\n", __PRETTY_FUNCTION__);
     clang_visitChildren(clang_getTranslationUnitCursor(m_ClTranslUnit), ClAST_Visitor, database);
-    database->Shrink();
+    fprintf(stdout,"%s Shrinking database\n", __PRETTY_FUNCTION__);
+    //database->Shrink();
+    fprintf(stdout,"%s Done\n", __PRETTY_FUNCTION__);
 }
 
 #if __cplusplus >= 201103L
@@ -52,21 +59,27 @@ TranslationUnit::TranslationUnit(TranslationUnit&& other) :
     m_Files(std::move(other.m_Files)),
     m_ClTranslUnit(other.m_ClTranslUnit),
     m_LastCC(nullptr),
-    m_LastPos(-1, -1)
+    m_LastPos(-1, -1),
+    m_Mutex()
 {
-     other.m_ClTranslUnit = nullptr;
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
+    other.m_ClTranslUnit = nullptr;
 }
 
-TranslationUnit::TranslationUnit(const TranslationUnit& WXUNUSED(other))
+TranslationUnit::TranslationUnit(const TranslationUnit& WXUNUSED(other)) :
+    m_Mutex()
 {
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     cbThrow(wxT("Illegal copy attempted of TranslationUnit object."));
 }
 #else
 TranslationUnit::TranslationUnit(const TranslationUnit& other) :
     m_ClTranslUnit(other.m_ClTranslUnit),
     m_LastCC(nullptr),
-    m_LastPos(-1, -1)
+    m_LastPos(-1, -1),
+    m_Mutex()
 {
+    fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     m_Files.swap(const_cast<TranslationUnit&>(other).m_Files);
     const_cast<TranslationUnit&>(other).m_ClTranslUnit = nullptr;
 }
@@ -80,30 +93,43 @@ TranslationUnit::~TranslationUnit()
         clang_disposeTranslationUnit(m_ClTranslUnit);
 }
 
+std::ostream& operator << (std::ostream& str, const std::vector<FileId> files)
+{
+    str<<"[ ";
+    for( std::vector<FileId>::const_iterator it = files.begin(); it != files.end(); ++it )
+    {
+        str<<*it<<", ";
+    }
+    str<<"]";
+    return str;
+}
+
 void TranslationUnit::AddInclude(FileId fId)
 {
     m_Files.push_back(fId);
+    //std::cout<<"Added include file id "<<fId<<" to "<<m_Files<<std::endl;
 }
 
 bool TranslationUnit::Contains(FileId fId)
 {
+    //std::cout<<"Checking file id "<<fId<<" in "<<m_Files<<std::endl;
     //return std::binary_search(m_Files.begin(), m_Files.begin() + std::min(fId + 1, m_Files.size()), fId);
     return std::binary_search(m_Files.begin(), m_Files.end(), fId);
 }
 
 CXCodeCompleteResults* TranslationUnit::CodeCompleteAt( const char* complete_filename, unsigned complete_line,
-                                       unsigned complete_column, struct CXUnsavedFile* unsaved_files,
-                                       unsigned num_unsaved_files )
+        unsigned complete_column, struct CXUnsavedFile* unsaved_files,
+        unsigned num_unsaved_files )
 {
     if (m_LastPos.Equals(complete_line, complete_column))
         return m_LastCC;
     if (m_LastCC)
         clang_disposeCodeCompleteResults(m_LastCC);
     m_LastCC = clang_codeCompleteAt(m_ClTranslUnit, complete_filename, complete_line, complete_column,
-                                    unsaved_files, num_unsaved_files,
-                                      clang_defaultCodeCompleteOptions()
-                                    | CXCodeComplete_IncludeCodePatterns
-                                    | CXCodeComplete_IncludeBriefComments);
+            unsaved_files, num_unsaved_files,
+            clang_defaultCodeCompleteOptions()
+            | CXCodeComplete_IncludeCodePatterns
+            | CXCodeComplete_IncludeBriefComments);
     m_LastPos.Set(complete_line, complete_column);
     return m_LastCC;
 }
@@ -124,7 +150,7 @@ void TranslationUnit::Reparse(unsigned num_unsaved_files, struct CXUnsavedFile* 
 {
     // TODO: check and handle error conditions
     clang_reparseTranslationUnit(m_ClTranslUnit, num_unsaved_files,
-                                 unsaved_files, clang_defaultReparseOptions(m_ClTranslUnit));
+            unsaved_files, clang_defaultReparseOptions(m_ClTranslUnit));
 }
 
 void TranslationUnit::GetDiagnostics(std::vector<ClDiagnostic>& diagnostics)
@@ -192,8 +218,8 @@ void TranslationUnit::ExpandDiagnosticSet(CXDiagnosticSet diagSet, std::vector<C
         clang_disposeString(str);
         str = clang_formatDiagnostic(diag, 0);
         diagnostics.push_back(ClDiagnostic( line, rgStart, rgEnd,
-                                            clang_getDiagnosticSeverity(diag) >= CXDiagnostic_Error ? sError : sWarning,
-                                            flName, wxString::FromUTF8(clang_getCString(str)) ));
+                clang_getDiagnosticSeverity(diag) >= CXDiagnostic_Error ? sError : sWarning,
+                flName, wxString::FromUTF8(clang_getCString(str)) ));
         clang_disposeString(str);
         clang_disposeDiagnostic(diag);
     }
@@ -220,7 +246,7 @@ unsigned HashToken(CXCompletionString token, wxString& identifier)
 }
 
 static void ClInclusionVisitor(CXFile included_file, CXSourceLocation* WXUNUSED(inclusion_stack),
-                               unsigned WXUNUSED(include_len), CXClientData client_data)
+        unsigned WXUNUSED(include_len), CXClientData client_data)
 {
     CXString filename = clang_getFileName(included_file);
     wxFileName inclFile(wxString::FromUTF8(clang_getCString(filename)));
@@ -238,31 +264,31 @@ static CXChildVisitResult ClAST_Visitor(CXCursor cursor, CXCursor WXUNUSED(paren
     CXChildVisitResult ret = CXChildVisit_Break; // should never happen
     switch (cursor.kind)
     {
-        case CXCursor_StructDecl:
-        case CXCursor_UnionDecl:
-        case CXCursor_ClassDecl:
-        case CXCursor_EnumDecl:
-        case CXCursor_Namespace:
-        case CXCursor_ClassTemplate:
-            ret = CXChildVisit_Recurse;
-            break;
+    case CXCursor_StructDecl:
+    case CXCursor_UnionDecl:
+    case CXCursor_ClassDecl:
+    case CXCursor_EnumDecl:
+    case CXCursor_Namespace:
+    case CXCursor_ClassTemplate:
+        ret = CXChildVisit_Recurse;
+        break;
 
-        case CXCursor_FieldDecl:
-        case CXCursor_EnumConstantDecl:
-        case CXCursor_FunctionDecl:
-        case CXCursor_VarDecl:
-        case CXCursor_ParmDecl:
-        case CXCursor_TypedefDecl:
-        case CXCursor_CXXMethod:
-        case CXCursor_Constructor:
-        case CXCursor_Destructor:
-        case CXCursor_FunctionTemplate:
+    case CXCursor_FieldDecl:
+    case CXCursor_EnumConstantDecl:
+    case CXCursor_FunctionDecl:
+    case CXCursor_VarDecl:
+    case CXCursor_ParmDecl:
+    case CXCursor_TypedefDecl:
+    case CXCursor_CXXMethod:
+    case CXCursor_Constructor:
+    case CXCursor_Destructor:
+    case CXCursor_FunctionTemplate:
         //case CXCursor_MacroDefinition: // this can crash Clang on Windows
-            ret = CXChildVisit_Continue;
-            break;
+        ret = CXChildVisit_Continue;
+        break;
 
-        default:
-            return CXChildVisit_Recurse;
+    default:
+        return CXChildVisit_Recurse;
     }
 
     CXSourceLocation loc = clang_getCursorLocation(cursor);

--- a/translationunit.cpp
+++ b/translationunit.cpp
@@ -22,8 +22,7 @@ static CXChildVisitResult ClAST_Visitor(CXCursor cursor, CXCursor parent, CXClie
 TranslationUnit::TranslationUnit(const wxString& filename, const std::vector<const char*>& args,
         CXIndex clIndex, TokenDatabase* database) :
     m_LastCC(nullptr),
-    m_LastPos(-1, -1),
-    m_Mutex()
+    m_LastPos(-1, -1)
 {
     fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     // TODO: check and handle error conditions
@@ -59,15 +58,13 @@ TranslationUnit::TranslationUnit(TranslationUnit&& other) :
     m_Files(std::move(other.m_Files)),
     m_ClTranslUnit(other.m_ClTranslUnit),
     m_LastCC(nullptr),
-    m_LastPos(-1, -1),
-    m_Mutex()
+    m_LastPos(-1, -1)
 {
     fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     other.m_ClTranslUnit = nullptr;
 }
 
-TranslationUnit::TranslationUnit(const TranslationUnit& WXUNUSED(other)) :
-    m_Mutex()
+TranslationUnit::TranslationUnit(const TranslationUnit& WXUNUSED(other))
 {
     fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     cbThrow(wxT("Illegal copy attempted of TranslationUnit object."));
@@ -76,8 +73,7 @@ TranslationUnit::TranslationUnit(const TranslationUnit& WXUNUSED(other)) :
 TranslationUnit::TranslationUnit(const TranslationUnit& other) :
     m_ClTranslUnit(other.m_ClTranslUnit),
     m_LastCC(nullptr),
-    m_LastPos(-1, -1),
-    m_Mutex()
+    m_LastPos(-1, -1)
 {
     fprintf(stdout,"%s\n", __PRETTY_FUNCTION__);
     m_Files.swap(const_cast<TranslationUnit&>(other).m_Files);

--- a/translationunit.h
+++ b/translationunit.h
@@ -25,7 +25,6 @@ public:
         swap(first.m_Files, second.m_Files);
         swap(first.m_ClTranslUnit, second.m_ClTranslUnit);
         swap(first.m_LastCC, second.m_LastCC);
-        // nowswap m_Mutex
     }
     TranslationUnit& operator=(TranslationUnit& other)
     {
@@ -46,11 +45,6 @@ public:
     void GetDiagnostics(std::vector<ClDiagnostic>& diagnostics);
     CXFile GetFileHandle(const wxString& filename) const;
 
-    wxMutex* Mutex()
-    {
-        return &m_Mutex;
-    }
-
 private:
 #if __cplusplus >= 201103L
     // copying not allowed (we can move)
@@ -62,7 +56,6 @@ private:
     std::vector<FileId> m_Files;
     CXTranslationUnit m_ClTranslUnit;
     CXCodeCompleteResults* m_LastCC;
-    wxMutex m_Mutex;
 
     struct FilePos
     {

--- a/translationunit.h
+++ b/translationunit.h
@@ -8,61 +8,81 @@ unsigned HashToken(CXCompletionString token, wxString& identifier);
 
 class TranslationUnit
 {
-    public:
-        TranslationUnit(const wxString& filename, const std::vector<const char*>& args,
-                        CXIndex clIndex, TokenDatabase* database);
-        // move ctor
+public:
+    TranslationUnit(const wxString& filename, const std::vector<const char*>& args,
+            CXIndex clIndex, TokenDatabase* database);
+    // move ctor
 #if __cplusplus >= 201103L
-        TranslationUnit(TranslationUnit&& other);
+    TranslationUnit(TranslationUnit&& other);
 #else
-        TranslationUnit(const TranslationUnit& other);
+    TranslationUnit(const TranslationUnit& other);
 #endif
-        ~TranslationUnit();
+    ~TranslationUnit();
 
-        void AddInclude(FileId fId);
-        bool Contains(FileId fId);
+    friend void swap( TranslationUnit& first, TranslationUnit& second )
+    {
+        using std::swap;
+        swap(first.m_Files, second.m_Files);
+        swap(first.m_ClTranslUnit, second.m_ClTranslUnit);
+        swap(first.m_LastCC, second.m_LastCC);
+        // nowswap m_Mutex
+    }
+    TranslationUnit& operator=(TranslationUnit& other)
+    {
+        swap(*this,other);
+        return *this;
+    }
 
-        // note that complete_line and complete_column are 1 index, not 0 index!
-        CXCodeCompleteResults* CodeCompleteAt( const char* complete_filename, unsigned complete_line,
-                                               unsigned complete_column, struct CXUnsavedFile* unsaved_files,
-                                               unsigned num_unsaved_files );
-        const CXCompletionResult* GetCCResult(unsigned index);
-        CXCursor GetTokensAt(const wxString& filename, int line, int column);
-        void Reparse(unsigned num_unsaved_files, struct CXUnsavedFile* unsaved_files);
-        void GetDiagnostics(std::vector<ClDiagnostic>& diagnostics);
-        CXFile GetFileHandle(const wxString& filename) const;
+    void AddInclude(FileId fId);
+    bool Contains(FileId fId);
 
-    private:
+    // note that complete_line and complete_column are 1 index, not 0 index!
+    CXCodeCompleteResults* CodeCompleteAt( const char* complete_filename, unsigned complete_line,
+            unsigned complete_column, struct CXUnsavedFile* unsaved_files,
+            unsigned num_unsaved_files );
+    const CXCompletionResult* GetCCResult(unsigned index);
+    CXCursor GetTokensAt(const wxString& filename, int line, int column);
+    void Reparse(unsigned num_unsaved_files, struct CXUnsavedFile* unsaved_files);
+    void GetDiagnostics(std::vector<ClDiagnostic>& diagnostics);
+    CXFile GetFileHandle(const wxString& filename) const;
+
+    wxMutex* Mutex()
+    {
+        return &m_Mutex;
+    }
+
+private:
 #if __cplusplus >= 201103L
-        // copying not allowed (we can move)
-        TranslationUnit(const TranslationUnit& other);
+    // copying not allowed (we can move)
+    TranslationUnit(const TranslationUnit& other);
 #endif
 
-        void ExpandDiagnosticSet(CXDiagnosticSet diagSet, std::vector<ClDiagnostic>& diagnostics);
+    void ExpandDiagnosticSet(CXDiagnosticSet diagSet, std::vector<ClDiagnostic>& diagnostics);
 
-        std::vector<FileId> m_Files;
-        CXTranslationUnit m_ClTranslUnit;
-        CXCodeCompleteResults* m_LastCC;
+    std::vector<FileId> m_Files;
+    CXTranslationUnit m_ClTranslUnit;
+    CXCodeCompleteResults* m_LastCC;
+    wxMutex m_Mutex;
 
-        struct FilePos
+    struct FilePos
+    {
+        FilePos(unsigned ln, unsigned col) :
+            line(ln), column(col) {}
+
+        void Set(unsigned ln, unsigned col)
         {
-            FilePos(unsigned ln, unsigned col) :
-                line(ln), column(col) {}
+            line   = ln;
+            column = col;
+        }
 
-            void Set(unsigned ln, unsigned col)
-            {
-                line   = ln;
-                column = col;
-            }
+        bool Equals(unsigned ln, unsigned col)
+        {
+            return (line == ln && column == col);
+        }
 
-            bool Equals(unsigned ln, unsigned col)
-            {
-                return (line == ln && column == col);
-            }
-
-            unsigned line;
-            unsigned column;
-        } m_LastPos;
+        unsigned line;
+        unsigned column;
+    } m_LastPos;
 };
 
 #endif // TRANSLATION_UNIT_H


### PR DESCRIPTION
Rework how the Compile command is being assembled to work around the fact that wxExecute allows the app to run OnTimer. The Compile-Command-string, needed for Clang to run is being built in an OnTimer event which causes a deadlock.

It's essentially when an wxExecute is ran, C::B allows events to be fired to keep the UI happy. That is a good thing, but it also allows OnTimer events to be fired. Previous code then performs another wxExecute to resolve backticks for the Compile command string trough an OnTimer event, which causes a deadlock in wxExecute.
This change works around this by moving the function that performs this wxExecute outside the OnTimer scope.
